### PR TITLE
Fix QuickLaunchApps extension check

### DIFF
--- a/frontend-web/webclient/app/Files/LowLevelFileTable.tsx
+++ b/frontend-web/webclient/app/Files/LowLevelFileTable.tsx
@@ -311,9 +311,16 @@ const LowLevelFileTable_: React.FunctionComponent<
                 filesOnly.forEach(f => {
                     const fileApps: QuickLaunchApp[] = [];
 
+                    const fileName = f.path.split("/").slice(-1)[0];
+                    let fileExtension = fileName.split(".").slice(-1)[0];
+
+                    if (fileName !== fileExtension) {
+                        fileExtension = `.${fileExtension}`;
+                    }
+
                     response.response.forEach(item => {
                         item.extensions.forEach(ext => {
-                            if (f.path.endsWith(ext)) {
+                            if (fileExtension === ext) {
                                 fileApps.push(item);
                             }
                         });


### PR DESCRIPTION
Fixes how file extensions are checked when finding matching quick launch apps. In case an app supports a full name, i.e. `Makefile`, the app should only be listed for files named `Makefile`, and not files which just ends with "Makefile", i.e. "testMakefile".