### PR TITLE
Use short jobId for job folders instead of timestamp

### DIFF
--- a/app-orchestrator-service/src/main/kotlin/dk/sdu/cloud/app/orchestrator/services/JobFileService.kt
+++ b/app-orchestrator-service/src/main/kotlin/dk/sdu/cloud/app/orchestrator/services/JobFileService.kt
@@ -196,12 +196,12 @@ class JobFileService(
 
     suspend fun jobFolder(job: VerifiedJob): String {
         val jobsFolder = jobsFolder(job.owner)
-        val timestamp = timestampFormatter.format(LocalDateTime.ofInstant(Date(job.createdAt).toInstant(), zoneId))
+        val shortUUID = job.id.substring(0, 8)
 
         val folderName: String = if (job.name == null) {
-            timestamp
+            shortUUID
         } else {
-            job.name + "-" + timestamp
+            job.name + "-" + shortUUID
         }
 
         return joinPath(


### PR DESCRIPTION
Changes the name of job folders to `[name-]uuid` instead of the current timestamp, as mentioned in issue #1027, where the uuid is identical to the one used as the _name_ of a job (in case a name is not set) on the frontend. That is, the first 8 characters of the job id.