### PR TITLE
Move file to owners' trash directory

### DIFF
--- a/file-trash-service/src/main/kotlin/dk/sdu/cloud/file/trash/services/TrashService.kt
+++ b/file-trash-service/src/main/kotlin/dk/sdu/cloud/file/trash/services/TrashService.kt
@@ -73,13 +73,13 @@ class TrashService(
         backgroundScope.launch {
             runTask(wsServiceClient, backgroundScope, "Moving files to trash", username) {
 
-                this.status =  "Moving files to trash"
+                this.status = "Moving files to trash"
                 val progress = Progress("Number of files", 0, files.size)
                 this.progress = progress
 
                 files.forEach {
                     launch {
-                         moveFileToTrash(it, username, userCloud)
+                        moveFileToTrash(it, username, userCloud)
                         progress.current++
                     }
                 }


### PR DESCRIPTION
When a file is moved to trash, it is moved to the owner's trash directory. In case the file has no owner, it will be moved to the users' trash directory.

fixes #1057 