### PR TITLE
Changes to type in elastic that was missed in another issue #1122

### DIFF
--- a/audit-ingestion-service/build.gradle
+++ b/audit-ingestion-service/build.gradle
@@ -1,5 +1,5 @@
 group 'dk.sdu.cloud'
-version '0.1.10'
+version '0.1.11'
 
 apply plugin: 'application'
 mainClassName = "dk.sdu.cloud.audit.ingestion.MainKt"

--- a/audit-ingestion-service/k8/deployment.yml
+++ b/audit-ingestion-service/k8/deployment.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: audit-ingestion
-        image: registry.cloud.sdu.dk/sdu-cloud/audit-ingestion-service:0.1.10
+        image: registry.cloud.sdu.dk/sdu-cloud/audit-ingestion-service:0.1.11
         livenessProbe:
           httpGet:
             port: 8080

--- a/audit-ingestion-service/src/main/kotlin/dk/sdu/cloud/audit/ingestion/processors/AuditProcessor.kt
+++ b/audit-ingestion-service/src/main/kotlin/dk/sdu/cloud/audit/ingestion/processors/AuditProcessor.kt
@@ -55,7 +55,7 @@ class AuditProcessor(
 
                     batch
                         .map { (_, doc) ->
-                            IndexRequest(indexName, "doc").apply {
+                            IndexRequest(indexName).apply {
                                 source(doc.toByteArray(Charsets.UTF_8), XContentType.JSON)
                             }
                         }

--- a/elastic-management/src/test/kotlin/dk/sdu/cloud/elastic/management/services/ManagementTest.kt
+++ b/elastic-management/src/test/kotlin/dk/sdu/cloud/elastic/management/services/ManagementTest.kt
@@ -44,7 +44,7 @@ class ManagementTest {
 
         var bulkRequest = BulkRequest()
         for (i in 0 until numberOfDocuments) {
-            val request = IndexRequest("$index-${pastdate}_small", "doc")
+            val request = IndexRequest("$index-${pastdate}_small")
             val jsonString = """
                 {
                     "user":"kimchy",


### PR DESCRIPTION
This should be a trivial PR. Changing from doc to _doc type in elastic. Missed these files last time.
When PR is approved, the Audit Ingestion should not be updated instantly. This is due to type conflict in the mapping of the http_logs indices. 
Ideally this should be done just after midnight, but at the start of the day should also be acceptable. 
