### PR TITLE
Issue1175

### DIFF
--- a/frontend-web/webclient/app/Applications/Studio/App.tsx
+++ b/frontend-web/webclient/app/Applications/Studio/App.tsx
@@ -361,9 +361,9 @@ const App: React.FunctionComponent<RouteComponentProps<{name: string}> & AppOper
                                     {versions.map(version => (
                                         <TableRow key={version.version}>
                                             <TableCell>
-                                                <Box style={{wordBreak: "break-word"}} width="100%">
+                                                <WordBreakBox>
                                                     {version.version}
-                                                </Box>
+                                                </WordBreakBox>
                                             </TableCell>
                                             <TableCell>
                                                 <Box mb={26} mt={16}>
@@ -432,6 +432,13 @@ const App: React.FunctionComponent<RouteComponentProps<{name: string}> & AppOper
         />
     );
 };
+
+const WordBreakBox = styled(Box)`
+    word-break: break-word;
+    width: 100%;
+`;
+
+
 
 const mapDispatchToProps = (
     dispatch: Dispatch<Actions.Type | HeaderActions | StatusActions | LoadingAction>


### PR DESCRIPTION
Removes the h3 heading (dont know why we had that) of versions column in app studio and substitutes it with word wrapping. 
Version kan be approx. 10 char long before it wraps. Should be enough.
<img width="841" alt="Screenshot 2020-02-04 at 14 58 39" src="https://user-images.githubusercontent.com/10943804/73751184-ddafb800-475e-11ea-9ef9-a23399147dac.png">
