### PR TITLE
Escape double quotes on request parameters

### DIFF
--- a/service-common/src/main/kotlin/dk/sdu/cloud/calls/server/IngoingHttpInterceptor.kt
+++ b/service-common/src/main/kotlin/dk/sdu/cloud/calls/server/IngoingHttpInterceptor.kt
@@ -24,7 +24,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.withCharset
 import io.ktor.request.header
-import io.ktor.request.queryString
 import io.ktor.request.receiveOrNull
 import io.ktor.response.respond
 import io.ktor.routing.method
@@ -32,7 +31,6 @@ import io.ktor.routing.route
 import io.ktor.routing.routing
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.util.DataConversionException
-import io.ktor.util.getValue
 import io.ktor.util.pipeline.PipelineContext
 import kotlinx.io.IOException
 import java.util.*


### PR DESCRIPTION
Unsure if there's any unhandled edge-cases to this, but (hopefully) fixes #1284 