### PR TITLE
Fix event streams only being read by a single consumer

### DIFF
--- a/backend/app-kubernetes-service/src/main/kotlin/app/kubernetes/services/K8JobMonitoringService.kt
+++ b/backend/app-kubernetes-service/src/main/kotlin/app/kubernetes/services/K8JobMonitoringService.kt
@@ -125,7 +125,7 @@ class K8JobMonitoringService(
                     }
                 }
             }
-        })
+        }, k8.nameAllocator.namespace)
     }
 
     suspend fun runPostCreateHandlers(

--- a/backend/app-license-service/src/main/kotlin/app/license/Server.kt
+++ b/backend/app-license-service/src/main/kotlin/app/license/Server.kt
@@ -1,5 +1,6 @@
 package dk.sdu.cloud.app.license
 
+import dk.sdu.cloud.ServiceDescription
 import dk.sdu.cloud.micro.*
 import dk.sdu.cloud.service.*
 import dk.sdu.cloud.app.license.rpc.*
@@ -11,6 +12,7 @@ import dk.sdu.cloud.app.license.services.acl.AclService
 import dk.sdu.cloud.auth.api.authenticator
 import dk.sdu.cloud.calls.client.OutgoingHttpCall
 import dk.sdu.cloud.service.db.async.AsyncDBSessionFactory
+import dk.sdu.cloud.app.license.api.AppLicenseServiceDescription
 
 class Server(override val micro: Micro) : CommonServer {
     override val log = logger()
@@ -22,8 +24,9 @@ class Server(override val micro: Micro) : CommonServer {
     val aclService = AclService(db, authenticatedClient, aclDao)
     val appLicenseService = AppLicenseService(db, aclService, appLicenseDao, authenticatedClient)
 
+
     override fun start() {
-        ProjectProcessor(streams, appLicenseService).init()
+        ProjectProcessor(streams, appLicenseService, AppLicenseServiceDescription).init()
         with(micro.server) {
             configureControllers(
                 AppLicenseController(appLicenseService)

--- a/backend/app-license-service/src/main/kotlin/app/license/processors/ProjectProcessor.kt
+++ b/backend/app-license-service/src/main/kotlin/app/license/processors/ProjectProcessor.kt
@@ -1,5 +1,6 @@
 package dk.sdu.cloud.app.license.processors
 
+import dk.sdu.cloud.ServiceDescription
 import dk.sdu.cloud.events.EventConsumer
 import dk.sdu.cloud.events.EventStreamService
 import dk.sdu.cloud.project.api.ProjectEvent
@@ -9,10 +10,11 @@ import dk.sdu.cloud.service.Loggable
 
 class ProjectProcessor(
     private val streams: EventStreamService,
-    private val appLicenseService: AppLicenseService
+    private val appLicenseService: AppLicenseService,
+    private val description: ServiceDescription
 ) {
     fun init() {
-        streams.subscribe(ProjectEvents.events, EventConsumer.Immediate(this::handleEvent))
+        streams.subscribe(ProjectEvents.events, EventConsumer.Immediate(this::handleEvent), description.name)
     }
 
     private suspend fun handleEvent(event: ProjectEvent) {

--- a/backend/app-orchestrator-service/src/main/kotlin/app/orchestrator/Server.kt
+++ b/backend/app-orchestrator-service/src/main/kotlin/app/orchestrator/Server.kt
@@ -19,6 +19,7 @@ import dk.sdu.cloud.service.TokenValidationJWT
 import dk.sdu.cloud.service.configureControllers
 import dk.sdu.cloud.service.db.async.AsyncDBSessionFactory
 import dk.sdu.cloud.service.startServices
+import dk.sdu.cloud.app.orchestrator.api.AppOrchestratorServiceDescription
 
 class Server(override val micro: Micro, val config: Configuration) : CommonServer {
     override val log = logger()
@@ -104,7 +105,8 @@ class Server(override val micro: Micro, val config: Configuration) : CommonServe
         AppProcessor(
             streams,
             jobOrchestrator,
-            applicationService
+            applicationService,
+            AppOrchestratorServiceDescription
         ).init()
 
         with(micro.server) {

--- a/backend/app-orchestrator-service/src/main/kotlin/app/orchestrator/processors/AppProcessor.kt
+++ b/backend/app-orchestrator-service/src/main/kotlin/app/orchestrator/processors/AppProcessor.kt
@@ -1,5 +1,6 @@
 package dk.sdu.cloud.app.orchestrator.processors
 
+import dk.sdu.cloud.ServiceDescription
 import dk.sdu.cloud.app.orchestrator.services.ApplicationService
 import dk.sdu.cloud.app.orchestrator.services.JobOrchestrator
 import dk.sdu.cloud.app.store.api.AppEvent
@@ -11,10 +12,11 @@ import dk.sdu.cloud.service.Loggable
 class AppProcessor(
     private val streams: EventStreamService,
     private val jobService: JobOrchestrator,
-    private val appService: ApplicationService
+    private val appService: ApplicationService,
+    private val description: ServiceDescription
 ) {
     fun init() {
-        streams.subscribe(AppStoreStreams.AppDeletedStream, EventConsumer.Immediate(this::handleEvent))
+        streams.subscribe(AppStoreStreams.AppDeletedStream, EventConsumer.Immediate(this::handleEvent), description.name)
     }
 
     private suspend fun handleEvent(event: AppEvent) {

--- a/backend/audit-ingestion-service/src/main/kotlin/audit/ingestion/Server.kt
+++ b/backend/audit-ingestion-service/src/main/kotlin/audit/ingestion/Server.kt
@@ -6,11 +6,7 @@ import dk.sdu.cloud.micro.elasticHighLevelClient
 import dk.sdu.cloud.micro.eventStreamService
 import dk.sdu.cloud.service.CommonServer
 import dk.sdu.cloud.service.startServices
-import org.apache.http.HttpHost
-import org.elasticsearch.client.RestClient
-import org.elasticsearch.client.RestHighLevelClient
-import java.net.InetAddress
-import java.net.UnknownHostException
+import dk.sdu.cloud.audit.ingestion.api.AuditIngestionServiceDescription
 
 class Server(override val micro: Micro) : CommonServer {
     override val log = logger()
@@ -18,7 +14,7 @@ class Server(override val micro: Micro) : CommonServer {
     override fun start() {
         val client = micro.elasticHighLevelClient
 
-        AuditProcessor(micro.eventStreamService, client).init()
+        AuditProcessor(micro.eventStreamService, client, AuditIngestionServiceDescription).init()
 
         startServices()
     }

--- a/backend/audit-ingestion-service/src/main/kotlin/audit/ingestion/processors/AuditProcessor.kt
+++ b/backend/audit-ingestion-service/src/main/kotlin/audit/ingestion/processors/AuditProcessor.kt
@@ -1,6 +1,7 @@
 package dk.sdu.cloud.audit.ingestion.processors
 
 import com.fasterxml.jackson.databind.node.ObjectNode
+import dk.sdu.cloud.ServiceDescription
 import dk.sdu.cloud.defaultMapper
 import dk.sdu.cloud.events.EventConsumer
 import dk.sdu.cloud.events.EventStream
@@ -28,7 +29,8 @@ object HttpLogsStream : EventStream<String> {
 
 class AuditProcessor(
     private val events: EventStreamService,
-    private val client: RestHighLevelClient
+    private val client: RestHighLevelClient,
+    private val description: ServiceDescription
 ) {
     fun init() {
         events.subscribe(HttpLogsStream, EventConsumer.Batched { rawBatch ->
@@ -63,7 +65,7 @@ class AuditProcessor(
                 .forEach { chunk ->
                     client.bulk(BulkRequest().also { it.add(chunk) }, RequestOptions.DEFAULT)
                 }
-        })
+        }, description.name)
     }
 
     companion object : Loggable {

--- a/backend/service-common/src/main/kotlin/events/EventStream.kt
+++ b/backend/service-common/src/main/kotlin/events/EventStream.kt
@@ -42,6 +42,7 @@ interface EventStreamService {
     fun <V : Any> subscribe(
         stream: EventStream<V>,
         consumer: EventConsumer<V>,
+        group: String,
         rescheduleIdleJobsAfterMs: Long = 1000 * 60 * 5L
     )
 

--- a/backend/service-common/src/main/kotlin/events/RedisStreamService.kt
+++ b/backend/service-common/src/main/kotlin/events/RedisStreamService.kt
@@ -65,7 +65,6 @@ internal object RedisScope : CoroutineScope, Loggable {
 
 class RedisStreamService(
     public val connManager: RedisConnectionManager,
-    private val group: String,
     private val consumerId: String
 ) : EventStreamService {
     private suspend fun initializeStream(redis: RedisAsyncCommands<String, String>, stream: EventStream<*>) {
@@ -81,14 +80,16 @@ class RedisStreamService(
     override fun <V : Any> subscribe(
         stream: EventStream<V>,
         consumer: EventConsumer<V>,
+        group: String,
         rescheduleIdleJobsAfterMs: Long
     ) {
-        internalSubscribe(stream, consumer, rescheduleIdleJobsAfterMs)
+        internalSubscribe(stream, consumer, group, rescheduleIdleJobsAfterMs)
     }
 
     private fun <V : Any> internalSubscribe(
         stream: EventStream<V>,
         consumer: EventConsumer<V>,
+        group: String,
         rescheduleIdleJobsAfterMs: Long,
         criticalFailureTimestamps: List<Long> = emptyList()
     ) {
@@ -202,6 +203,7 @@ class RedisStreamService(
                 internalSubscribe(
                     stream,
                     consumer,
+                    group,
                     rescheduleIdleJobsAfterMs,
                     criticalFailureTimestamps + System.currentTimeMillis()
                 )

--- a/backend/service-common/src/main/kotlin/micro/HealthCheckFeature.kt
+++ b/backend/service-common/src/main/kotlin/micro/HealthCheckFeature.kt
@@ -180,7 +180,7 @@ class HealthCheckFeature : MicroFeature {
             if (event.id == uuid && now - event.timestamp < REDIS_HEALTH_STREAM_MESSAGE_MAX_AGE) {
                 lastObservedRedisMessage = now
             }
-        })
+        }, ctx.serviceDescription.name)
 
         lastObservedRedisMessage = System.currentTimeMillis()
         return true

--- a/backend/service-common/src/main/kotlin/micro/RedisFeature.kt
+++ b/backend/service-common/src/main/kotlin/micro/RedisFeature.kt
@@ -36,7 +36,6 @@ class RedisFeature : MicroFeature {
 
         ctx.eventStreamService = RedisStreamService(
             ctx.redisConnectionManager,
-            ctx.serviceDescription.name,
             ctx.serviceInstance.hostname
         )
 

--- a/backend/storage-service/src/main/kotlin/file/Server.kt
+++ b/backend/storage-service/src/main/kotlin/file/Server.kt
@@ -35,6 +35,7 @@ import dk.sdu.cloud.service.configureControllers
 import dk.sdu.cloud.service.db.async.AsyncDBSessionFactory
 import dk.sdu.cloud.service.startServices
 import dk.sdu.cloud.file.processors.ProjectProcessor
+import dk.sdu.cloud.storage.api.StorageServiceDescription
 import kotlinx.coroutines.runBlocking
 import org.slf4j.Logger
 import java.io.File
@@ -89,10 +90,11 @@ class Server(
         UserProcessor(
             streams,
             fsRootFile,
-            homeFolderService
+            homeFolderService,
+            StorageServiceDescription
         ).init()
 
-        ProjectProcessor(streams, fsRootFile, client).init()
+        ProjectProcessor(streams, fsRootFile, client, StorageServiceDescription).init()
 
         val metadataRecovery = MetadataRecoveryService(
             micro.backgroundScope,

--- a/backend/storage-service/src/main/kotlin/file/processors/ProjectProcessor.kt
+++ b/backend/storage-service/src/main/kotlin/file/processors/ProjectProcessor.kt
@@ -1,5 +1,6 @@
 package dk.sdu.cloud.file.processors
 
+import dk.sdu.cloud.ServiceDescription
 import dk.sdu.cloud.calls.client.AuthenticatedClient
 import dk.sdu.cloud.calls.client.call
 import dk.sdu.cloud.events.EventConsumer
@@ -17,10 +18,11 @@ import java.nio.file.attribute.PosixFilePermissions
 class ProjectProcessor(
     private val streams: EventStreamService,
     private val rootFolder: File,
-    private val authenticatedClient: AuthenticatedClient
+    private val authenticatedClient: AuthenticatedClient,
+    private val description: ServiceDescription
 ) {
     fun init() {
-        streams.subscribe(ProjectEvents.events, EventConsumer.Immediate(this::handleEvent))
+        streams.subscribe(ProjectEvents.events, EventConsumer.Immediate(this::handleEvent), description.name)
     }
 
     private suspend fun handleEvent(event: ProjectEvent) {

--- a/backend/storage-service/src/main/kotlin/file/processors/UserProcessor.kt
+++ b/backend/storage-service/src/main/kotlin/file/processors/UserProcessor.kt
@@ -1,6 +1,7 @@
 package dk.sdu.cloud.file.processors
 
 import dk.sdu.cloud.Role
+import dk.sdu.cloud.ServiceDescription
 import dk.sdu.cloud.auth.api.AuthStreams
 import dk.sdu.cloud.auth.api.UserEvent
 import dk.sdu.cloud.events.EventConsumer
@@ -17,10 +18,11 @@ import java.nio.file.attribute.PosixFilePermissions
 class UserProcessor(
     private val streams: EventStreamService,
     private val rootFolder: File,
-    private val homeFolderService: HomeFolderService
+    private val homeFolderService: HomeFolderService,
+    private val description: ServiceDescription
 ) {
     fun init() {
-        streams.subscribe(AuthStreams.UserUpdateStream, EventConsumer.Immediate(this::handleEvent))
+        streams.subscribe(AuthStreams.UserUpdateStream, EventConsumer.Immediate(this::handleEvent), description.name)
     }
 
     private suspend fun handleEvent(event: UserEvent) {


### PR DESCRIPTION
Problem described in #1656 

Fixed by allowing the `subscribe` method of `EventStreamService` to take a consumer `group` parameter, and removing the global consumer `group` variable.

We set the consumer group parameter to `ServiceDescription.name` to allow load balancing between multiple instances of the same service.

Fixes #1656 