### PR TITLE
Minor changes to Project Application page

### DIFF
--- a/frontend-web/webclient/app/Project/Grant/GrantApplicationEditor.tsx
+++ b/frontend-web/webclient/app/Project/Grant/GrantApplicationEditor.tsx
@@ -390,12 +390,16 @@ export const GrantApplicationEditor: (target: RequestTarget) => React.FunctionCo
                 )
             );
 
+
             if (wb.area === ProductArea.STORAGE) {
-                if ((creditsRequested === undefined) !== (quotaRequested === undefined)) {
-                    snackbarStore.addFailure("Please fill out both Resources and Quota for requested storage product", false);
-                    return;
+                if ((creditsRequested !== undefined) || (quotaRequested !== undefined)) {
+                    if ((creditsRequested === undefined) || (quotaRequested === undefined)) {
+                        snackbarStore.addFailure("Please fill out both "Resources" and "Quota" for requested storage product", false);
+                        return;
+                    }
                 }
             }
+
 
             if (quotaRequested) quotaRequested = quotaRequested * (1000 * 1000 * 1000);
 


### PR DESCRIPTION
fixes #1800 

Prevents the user from submitting if only resource or quota is filled for a storage product, however I did not find a way to make it clear to the user in advance.