### PR TITLE
Attempt to fix quota problem

### DIFF
--- a/backend/storage-service/build.gradle.kts
+++ b/backend/storage-service/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "4.2.15-1"
+version = "4.2.15-2"
 
 application {
     mainClassName = "dk.sdu.cloud.file.MainKt"

--- a/backend/storage-service/k8.kts
+++ b/backend/storage-service/k8.kts
@@ -3,7 +3,7 @@ package dk.sdu.cloud.k8
 
 bundle { ctx ->
     name = "storage"
-    version = "4.2.15-1"
+    version = "4.2.15-2"
 
     val mountLocation: String = config("mountLocation", "Sub path in volume (e.g. 'test')", "")
 

--- a/backend/storage-service/src/test/kotlin/file/http/DownloadTests.kt
+++ b/backend/storage-service/src/test/kotlin/file/http/DownloadTests.kt
@@ -66,7 +66,8 @@ class DownloadTests : WithBackgroundScope() {
                     CommandRunnerFactoryForCalls(it.runner, mockk(relaxed = true)),
                     it.coreFs,
                     tokenValidation,
-                    it.lookupService
+                    it.lookupService,
+                    it.fsRoot
                 )
             )
         }


### PR DESCRIPTION
QuotaInBytes now does not subtract the allocation to subprojects (since we allowed over allocation we went into negative) but will now subtract what the subprojects (depth 1) actually use instead. 
This might be less usefull if the project is high-hierachy since its subproject only allocated futher down the line.
