### PR TITLE
Quota cleanup

### DIFF
--- a/backend/storage-service/api/src/main/kotlin/FileDescriptions.kt
+++ b/backend/storage-service/api/src/main/kotlin/FileDescriptions.kt
@@ -254,15 +254,37 @@ data class CreatePersonalRepositoryRequest(val project: String, val username: St
 
 typealias CreatePersonalRepositoryResponse = Unit
 
-data class RetrieveQuotaRequest(val path: String, val includeUsage: Boolean = false)
+data class RetrieveQuotaRequest(
+    val path: String,
+    /**
+     * Include own usage in response
+     */
+    val includeUsage: Boolean = false
+)
 typealias RetrieveQuotaResponse = Quota
 
 data class Quota(
+    /**
+     * allocated quota from other projects
+     */
     val quotaInTotal: Long,
-    val quotaInBytes: Long,
-    val allocated: Long,
-    val quotaUsed: Long? = null
-)
+    /**
+     * quota which has not yet been allocated to sub-projects
+     */
+    val remainingQuota: Long,
+    /**
+     * quota which has been allocated to sub-projects
+     */
+    val allocatedToSubProjects: Long,
+    /**
+     * actual usage in the current project
+     */
+    val inProjectUsage: Long? = null
+) {
+    val quotaInBytes = remainingQuota
+    val allocated = allocatedToSubProjects
+    val quotaUsed = inProjectUsage
+}
 
 data class UpdateQuotaRequest(val path: String, val quotaInBytes: Long, val additive: Boolean = false)
 typealias UpdateQuotaResponse = Unit

--- a/backend/storage-service/build.gradle.kts
+++ b/backend/storage-service/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "4.2.18-QUOTA4"
+version = "4.2.18"
 
 application {
     mainClassName = "dk.sdu.cloud.file.MainKt"

--- a/backend/storage-service/build.gradle.kts
+++ b/backend/storage-service/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "4.2.17"
+version = "4.2.18-QUOTA4"
 
 application {
     mainClassName = "dk.sdu.cloud.file.MainKt"

--- a/backend/storage-service/k8.kts
+++ b/backend/storage-service/k8.kts
@@ -3,7 +3,7 @@ package dk.sdu.cloud.k8
 
 bundle { ctx ->
     name = "storage"
-    version = "4.2.17"
+    version = "4.2.18-QUOTA4"
 
     val mountLocation: String = config("mountLocation", "Sub path in volume (e.g. 'test')", "")
 

--- a/backend/storage-service/k8.kts
+++ b/backend/storage-service/k8.kts
@@ -3,7 +3,7 @@ package dk.sdu.cloud.k8
 
 bundle { ctx ->
     name = "storage"
-    version = "4.2.18-QUOTA4"
+    version = "4.2.18"
 
     val mountLocation: String = config("mountLocation", "Sub path in volume (e.g. 'test')", "")
 

--- a/backend/storage-service/src/main/kotlin/file/http/ActionController.kt
+++ b/backend/storage-service/src/main/kotlin/file/http/ActionController.kt
@@ -147,7 +147,7 @@ class ActionController<Ctx : FSUserContext>(
                 }
             }
 
-            ok(quota.copy(quotaUsed = usage))
+            ok(quota.copy(inProjectUsage = usage))
         }
 
         implement(FileDescriptions.transferQuota) {


### PR DESCRIPTION
Changes variable names for Quota class and added check on quota allocations for subproject when changing project allocation. Used so that a project cannot be lower to more than it already have allocated it self (no over allocation). This should also remove all problems and fix #1909 .

There have not been create a potential script for projects were allocation is already overallocated.