### PR TITLE
attempt to fix wayf user creation issue

### DIFF
--- a/backend/auth-service/src/main/kotlin/auth/services/UserAsyncDAO.kt
+++ b/backend/auth-service/src/main/kotlin/auth/services/UserAsyncDAO.kt
@@ -415,16 +415,33 @@ class UserAsyncDAO(
      */
     suspend fun insert(db: DBContext, principal: Principal) {
         db.withSession { session ->
-            val found = session.sendPreparedStatement(
-                {
-                    setParameter("id", principal.id)
-                },
-                """
-                    SELECT *
-                    FROM principals
-                    WHERE id = :id
-                """
-            ).rows.singleOrNull()
+            val found =
+                when (principal) {
+                    is Person.ByWAYF -> {
+                        session.sendPreparedStatement(
+                            {
+                                setParameter("id", principal.wayfId)
+                            },
+                            """
+                                SELECT *
+                                FROM principals
+                                WHERE wayf_id = :id
+                            """
+                        ).rows.singleOrNull()
+                    }
+                    else -> {
+                        session.sendPreparedStatement(
+                            {
+                                setParameter("id", principal.id)
+                            },
+                            """
+                                SELECT *
+                                FROM principals
+                                WHERE id = :id
+                            """
+                        ).rows.singleOrNull()
+                    }
+                }
             if (found != null) {
                 throw UserException.AlreadyExists()
             } else {

--- a/backend/ucloud-data-extraction-service/src/main/kotlin/services/UserActivityReport.kt
+++ b/backend/ucloud-data-extraction-service/src/main/kotlin/services/UserActivityReport.kt
@@ -1,0 +1,4 @@
+package dk.sdu.cloud.ucloud.data.extraction.services
+
+class UserActivityReport {
+}


### PR DESCRIPTION
We had an issue when creating a WAYF user. Perhaps due to retires there was two users created before we could check, resulting in null value (singleOrNull). This fix makes a check in insert function if the user is from WAYF to check on WAYFID instead of our user generated ID this should make the situation more unlikely. 