### PR TITLE
Fixed incorrect last_scan timestamp and output folder path for jobs

### DIFF
--- a/backend/app-orchestrator-service/src/jvmMain/kotlin/services/JobFileService.kt
+++ b/backend/app-orchestrator-service/src/jvmMain/kotlin/services/JobFileService.kt
@@ -34,7 +34,7 @@ class JobFileService(
         val userClient = userClientFactory(refreshToken)
 
         val project = job.owner.project
-        val jobsFolder = jobsFolder(job.owner.launchedBy, project)
+        val jobsFolder = jobsFolder(job.owner.createdBy, project)
         if (project != null) {
             // Create the personal repository lazily
             FileDescriptions.createPersonalRepository.call(
@@ -190,7 +190,7 @@ class JobFileService(
         if (outputFolder != null) {
             return outputFolder
         } else {
-            val jobsFolder = jobsFolder(job.owner.launchedBy, job.owner.project)
+            val jobsFolder = jobsFolder(job.owner.createdBy, job.owner.project)
             var folderName = job.id
 
             if (new) {

--- a/backend/app-orchestrator-service/src/jvmMain/kotlin/services/JobMonitoringService.kt
+++ b/backend/app-orchestrator-service/src/jvmMain/kotlin/services/JobMonitoringService.kt
@@ -6,12 +6,10 @@ import dk.sdu.cloud.app.orchestrator.api.JobDataIncludeFlags
 import dk.sdu.cloud.app.orchestrator.api.JobState
 import dk.sdu.cloud.app.orchestrator.api.JobsControlUpdateRequestItem
 import dk.sdu.cloud.calls.bulkRequestOf
-import dk.sdu.cloud.calls.client.AuthenticatedClient
 import dk.sdu.cloud.calls.client.call
 import dk.sdu.cloud.micro.BackgroundScope
 import dk.sdu.cloud.service.*
 import dk.sdu.cloud.service.db.async.DBContext
-import dk.sdu.cloud.service.db.async.getField
 import dk.sdu.cloud.service.db.async.sendPreparedStatement
 import dk.sdu.cloud.service.db.async.withSession
 import io.ktor.http.*
@@ -50,7 +48,7 @@ class JobMonitoringService(
         var nextScan = 0L
 
         while (isActive) {
-            val now = Time.now()
+            val now = Time.now() / 1000
             if (now >= nextScan) {
                 db.withSession { session ->
                     val jobs = session
@@ -128,7 +126,7 @@ class JobMonitoringService(
                     }
                 }
 
-                nextScan = Time.now() + 30_000
+                nextScan = (Time.now() + 30_000) / 1000
             }
 
             if (!lock.renew(90_000)) {
@@ -140,6 +138,6 @@ class JobMonitoringService(
 
     companion object : Loggable {
         override val log = logger()
-        private const val TIME_BETWEEN_SCANS = 1_000 * 60 * 15
+        private const val TIME_BETWEEN_SCANS = 60 * 15
     }
 }

--- a/backend/storage-service/api/src/commonMain/kotlin/PathUtils.kt
+++ b/backend/storage-service/api/src/commonMain/kotlin/PathUtils.kt
@@ -32,7 +32,9 @@ fun findHomeDirectoryFromPath(path: String): String {
 }
 
 fun joinPath(vararg components: String, isDirectory: Boolean = false): String {
-    val basePath = components.joinToString("/") + (if (isDirectory) "/" else "").normalize()
+    val basePath = components.map {
+        it.removeSuffix("/")
+    }.joinToString("/") + (if (isDirectory) "/" else "").normalize()
     return if (basePath.startsWith("/")) basePath
     else "/$basePath"
 }


### PR DESCRIPTION
fixes #2294 

Also fixes a bug in in the `joinPath` utility function, which caused output folders to be created/saved with double `/`, i.e. `/home/user/Jobs/Coder/12345/` would be saved as `/home/user//Jobs//Coder/12345/` because of how `joinPath` joined paths with trailing `/` together.