### PR TITLE
RenamingIssue

### DIFF
--- a/backend/project-service/api/src/commonMain/kotlin/Projects.kt
+++ b/backend/project-service/api/src/commonMain/kotlin/Projects.kt
@@ -217,6 +217,9 @@ data class AllowsRenamingResponse(
     val allowed: Boolean
 )
 
+typealias RetrieveSubProjectRenamingSettingRequest = AllowsRenamingRequest
+typealias RetrieveSubProjectRenamingSettingResponse = AllowsRenamingResponse
+
 @Serializable
 data class UpdateDataManagementPlanRequest(val id: String, val dmp: String? = null)
 typealias UpdateDataManagementPlanResponse = Unit
@@ -893,7 +896,7 @@ object Projects : CallDescriptionContainer("project") {
         }
     }
 
-    val allowsSubProjectRenaming = call<AllowsRenamingRequest, AllowsRenamingResponse, CommonErrorMessage>("allowsSubProjectRenaming") {
+    val retrieveSubProjectRenamingSetting = call<RetrieveSubProjectRenamingSettingRequest, RetrieveSubProjectRenamingSettingResponse, CommonErrorMessage>("allowsSubProjectRenaming") {
         auth {
             access = AccessRight.READ
             roles = Roles.AUTHENTICATED

--- a/backend/project-service/build.gradle.kts
+++ b/backend/project-service/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "3.5.2"
+version = "3.5.3"
 
 application {
     mainClassName = "dk.sdu.cloud.project.MainKt"

--- a/backend/project-service/k8.kts
+++ b/backend/project-service/k8.kts
@@ -3,7 +3,7 @@ package dk.sdu.cloud.k8
 
 bundle { ctx ->
     name = "project"
-    version = "3.5.2"
+    version = "3.5.3"
 
     withAmbassador("/api/projects") {}
 

--- a/backend/project-service/src/jvmMain/kotlin/project/rpc/ProjectController.kt
+++ b/backend/project-service/src/jvmMain/kotlin/project/rpc/ProjectController.kt
@@ -286,10 +286,7 @@ class ProjectController(
         }
 
         implement(Projects.rename) {
-            val requestedProject = queries.lookupById(db, request.id) ?: throw RPCException(
-                "No project with that id",
-                HttpStatusCode.BadRequest
-            )
+            val requestedProject = queries.lookupById(db, request.id) ?: throw RPCException.fromStatusCode(HttpStatusCode.NotFound)
             if (requestedProject.parent != null && requestedProject.parent == ctx.project) {
                 val isAdmin = queries.isAdminOrPIOfProject(db, ctx.securityPrincipal.username, requestedProject.parent!!)
                 if (isAdmin) {
@@ -301,7 +298,7 @@ class ProjectController(
                         subProject = true
                     )
                 } else {
-                    throw RPCException.fromStatusCode(HttpStatusCode.Forbidden, "Not admin")
+                    throw RPCException.fromStatusCode(HttpStatusCode.NotFound)
                 }
             } else {
                 projects.renameProject(

--- a/backend/project-service/src/jvmMain/kotlin/project/services/ProjectService.kt
+++ b/backend/project-service/src/jvmMain/kotlin/project/services/ProjectService.kt
@@ -768,10 +768,13 @@ class ProjectService(
         ctx: DBContext,
         actor: Actor,
         projectId: String,
-        newTitle: String
+        newTitle: String,
+        subProject: Boolean = false
     ) {
         ctx.withSession { session ->
-            requireAdmin(session, projectId, actor)
+            if (!subProject) {
+                requireAdmin(session, projectId, actor)
+            }
             try {
                 session.sendPreparedStatement(
                     {

--- a/frontend-web/webclient/app/Project/Subprojects.tsx
+++ b/frontend-web/webclient/app/Project/Subprojects.tsx
@@ -454,7 +454,6 @@ const SubprojectRow: React.FunctionComponent<{
     const subprojectRenamingRef = useRef<HTMLInputElement>(null);
     const quotaRef = useRef<HTMLInputElement>(null);
     const [loading, runCommand] = useCloudCommand();
-    const [canRename, fetchCanRename] = useCloudAPI<{allowed: boolean}>({noop: true}, {allowed: false});
     const [quota, fetchQuota, quotaParams] = useCloudAPI<RetrieveQuotaResponse>(
         getRenamingStatusForSubProject({projectId: subproject.id}),
         {quotaInBytes: 0, quotaInTotal: 0}
@@ -466,8 +465,6 @@ const SubprojectRow: React.FunctionComponent<{
         if (walletBalance && isQuotaSupported(walletBalance.wallet.paysFor)) {
             fetchQuota(retrieveQuota({path: `/projects/${subproject.id}`}));
         }
-
-        fetchCanRename(getRenamingStatusForSubProject({projectId: subproject.id}));
     }, [subproject.id, walletBalance?.wallet?.paysFor?.id, walletBalance?.wallet?.paysFor?.provider]);
 
     const onSubmit = useCallback(async (e) => {
@@ -557,7 +554,7 @@ const SubprojectRow: React.FunctionComponent<{
     return <>
         <ListRow
             left={
-                isEditingName && allowManagement ?
+                isEditingName && allowManagement ? (
                     <>
                         <Input ref={subprojectRenamingRef} fontSize="large" defaultValue={subproject.title} />
                         <ButtonGroup ml="8px" width="130px">
@@ -565,8 +562,15 @@ const SubprojectRow: React.FunctionComponent<{
                             <Button width="45px" color="red" onClick={() => setEditingName(false)}><Icon name="close" /></Button>
                         </ButtonGroup>
                     </>
-                    : <Text>{subproject.title}</Text>
-
+                    )
+                    : (
+                    <>
+                        <Button pr={8} pl={8} onClick={() => setEditingName(true)}>
+                            <Icon name="edit" size={14} />
+                        </Button>
+                        <Text ml={10}>{subproject.title}</Text>
+                    </>
+                    )
             }
             right={!allowManagement || isEditingName ? null : (
                 <>

--- a/frontend-web/webclient/app/Project/Subprojects.tsx
+++ b/frontend-web/webclient/app/Project/Subprojects.tsx
@@ -556,7 +556,7 @@ const SubprojectRow: React.FunctionComponent<{
             left={
                 isEditingName && allowManagement ? (
                     <>
-                        <Button pr={8} pl={8} disabled={isEditingName}>
+                        <Button pr={8} pl={8} disabled>
                             <Icon name="edit" size={14} />
                         </Button>
                         <Input ml={10} ref={subprojectRenamingRef} fontSize="large" defaultValue={subproject.title} />

--- a/frontend-web/webclient/app/Project/Subprojects.tsx
+++ b/frontend-web/webclient/app/Project/Subprojects.tsx
@@ -556,7 +556,10 @@ const SubprojectRow: React.FunctionComponent<{
             left={
                 isEditingName && allowManagement ? (
                     <>
-                        <Input ref={subprojectRenamingRef} fontSize="large" defaultValue={subproject.title} />
+                        <Button pr={8} pl={8} disabled={isEditingName}>
+                            <Icon name="edit" size={14} />
+                        </Button>
+                        <Input ml={10} ref={subprojectRenamingRef} fontSize="large" defaultValue={subproject.title} />
                         <ButtonGroup ml="8px" width="130px">
                             <Button width="45px" color="green" onClick={renameSubproject} attached><Icon name="check" /></Button>
                             <Button width="45px" color="red" onClick={() => setEditingName(false)}><Icon name="close" /></Button>


### PR DESCRIPTION
Parent Projects can now always rename subprojects. Projects themself are stil only allowed to rename if parent allows. Fixes #2132
<img width="1148" alt="Screenshot 2021-04-14 at 21 22 11" src="https://user-images.githubusercontent.com/10943804/114767594-1df9c580-9d68-11eb-9030-28bf4371da92.png">
<img width="1086" alt="Screenshot 2021-04-14 at 21 22 17" src="https://user-images.githubusercontent.com/10943804/114767597-1fc38900-9d68-11eb-89fb-585c8c962265.png">

