### PR TITLE
Index break

### DIFF
--- a/backend/indexing-service/build.gradle.kts
+++ b/backend/indexing-service/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "1.19.9"
+version = "1.19.12-1"
 
 application {
     mainClassName = "dk.sdu.cloud.indexing.MainKt"

--- a/backend/indexing-service/k8.kts
+++ b/backend/indexing-service/k8.kts
@@ -3,7 +3,7 @@ package dk.sdu.cloud.k8
 
 bundle { ctx ->
     name = "indexing"
-    version = "1.19.9"
+    version = "1.19.12-1"
 
     withAmbassador {}
 

--- a/backend/indexing-service/src/jvmMain/kotlin/indexing/services/FileSystemScanner.kt
+++ b/backend/indexing-service/src/jvmMain/kotlin/indexing/services/FileSystemScanner.kt
@@ -116,6 +116,12 @@ class FileSystemScanner(
         }
 
         val fileList = (path.listFiles() ?: emptyArray()).filter { !Files.isSymbolicLink(Path.of(it.path)) }
+        fileList.forEach {
+            if (it.name == ".skipFolder") {
+                log.info("Skipping $path due to .skipFolder file")
+                return
+            }
+        }
         val files = fileList.map { it.toElasticIndexedFile() }.associateBy { it.path }
         val filesInIndex = query.query(
             FileQuery(


### PR DESCRIPTION
Added check for file .skipFolder when entering a directory.
If file is present it skips the entire folder and subfolders.
Fixes #2375 