### PR TITLE
Hide search icon on small displays

### DIFF
--- a/frontend-web/webclient/app/Navigation/Header.tsx
+++ b/frontend-web/webclient/app/Navigation/Header.tsx
@@ -77,10 +77,6 @@ function Header(props: HeaderProps): JSX.Element | null {
     if (useFrameHidden()) return null;
     if (!Client.isLoggedIn) return null;
 
-    function toSearch(): void {
-        history.push("/search/files");
-    }
-
     const {refresh, spin} = props;
 
     return (
@@ -90,15 +86,6 @@ function Header(props: HeaderProps): JSX.Element | null {
             <ui.Box ml="auto" />
             <ui.Hide xs sm md lg>
                 <Search />
-            </ui.Hide>
-            <ui.Hide xxl xl>
-                <ui.Icon
-                    name="search"
-                    size="32"
-                    mr="3px"
-                    cursor="pointer"
-                    onClick={toSearch}
-                />
             </ui.Hide>
             <ui.Box mr="auto" />
             {upcomingDowntime !== -1 ? (


### PR DESCRIPTION
Wasn't working, however we might want to come up with a solution such that users can still search on small displays.

When clicking the search icon it just led to a "Page not found" (probably the "old" file search page).