### PR TITLE
Minor improvements to metadata UI

### DIFF
--- a/frontend-web/webclient/app/Files/Metadata/Documents/History.tsx
+++ b/frontend-web/webclient/app/Files/Metadata/Documents/History.tsx
@@ -265,7 +265,7 @@ const entryRenderer: ItemRenderer<DocumentRow> = {
 const entryOperations: Operation<DocumentRow, StandardCallbacks<DocumentRow> & ActivityCallbacks>[] = [
     {
         icon: "close",
-        text: "Cancel new document",
+        text: "Close new document",
         primary: true,
         enabled: (selected, cb) => selected.length === 0 && cb.documentInspection === null,
         onClick: (selected, cb) => {

--- a/frontend-web/webclient/app/Files/Metadata/Documents/History.tsx
+++ b/frontend-web/webclient/app/Files/Metadata/Documents/History.tsx
@@ -192,7 +192,7 @@ export const History: React.FunctionComponent<{
 
             {hasActivity ?
                 <div className={"activity"}>
-                    <div className="scroll-area">
+                    <div className="scroll-area" style={{paddingTop: "5px"}}>
                         <StandardList
                             generateCall={noopCall} renderer={entryRenderer} embedded={"inline"}
                             title={"Activity entry"} titlePlural={"Activity"} preloadedResources={activityRows}

--- a/frontend-web/webclient/app/Files/Metadata/JsonSchemaForm.tsx
+++ b/frontend-web/webclient/app/Files/Metadata/JsonSchemaForm.tsx
@@ -99,4 +99,10 @@ const FormWrapper = styled.div`
     padding: 7px 12px;
     width: 100%;
   }
+
+  input[type="checkbox"] {
+    display: inline;
+    width: auto;
+    margin-right: 10px;
+  }
 `;


### PR DESCRIPTION
I've tried to make a few improvements to the metadata UI.

In particular:
 - fixes #3041 . Although I think it makes sense to remove the "description" from the favorites metadata template, and make sure that titles have a upper-case starting letter (in the database).
 - As mentioned in #2882 there's some weird behavior on the "New document" and "Close document" buttons. I've attempted to fix this by:
   - By default the active/most recent document is shown
   - "New document" opens the new document editor
   - "Close new document" returns to the most recent document
   - Saving a new document goes to the most recent document, instead of displaying the new document editor. 
