### PR TITLE
Error message on file/folder conflicts

### DIFF
--- a/backend/file-ucloud-service/src/jvmMain/kotlin/rpc/FilesController.kt
+++ b/backend/file-ucloud-service/src/jvmMain/kotlin/rpc/FilesController.kt
@@ -129,6 +129,14 @@ class FilesController(
                 limitChecker.checkLimit(reqItem.resolvedNewCollection)
             }
 
+            for (reqItem in request.items) {
+                if (reqItem.oldId.substringBeforeLast('/') == reqItem.newId.substringBeforeLast('/')) {
+                    if (fileQueries.fileExists(UCloudFile.create(reqItem.newId))) {
+                        throw RPCException("File or folder already exists", HttpStatusCode.Conflict)
+                    }
+                }
+            }
+
             ok(
                 BulkResponse(
                     request.items.map { reqItem ->
@@ -191,6 +199,12 @@ class FilesController(
         implement(UCloudFiles.createFolder) {
             for (reqItem in request.items) {
                 limitChecker.checkLimit(reqItem.resolvedCollection)
+            }
+
+            for (reqItem in request.items) {
+                if (fileQueries.fileExists(UCloudFile.create(reqItem.id))) {
+                    throw RPCException("Folder already exists", HttpStatusCode.Conflict)
+                }
             }
 
             ok(

--- a/backend/file-ucloud-service/src/jvmMain/kotlin/rpc/FilesController.kt
+++ b/backend/file-ucloud-service/src/jvmMain/kotlin/rpc/FilesController.kt
@@ -131,7 +131,8 @@ class FilesController(
 
             for (reqItem in request.items) {
                 if (reqItem.oldId.substringBeforeLast('/') == reqItem.newId.substringBeforeLast('/')) {
-                    if (fileQueries.fileExists(UCloudFile.create(reqItem.newId))) {
+                    if (reqItem.conflictPolicy == WriteConflictPolicy.REJECT &&
+                        fileQueries.fileExists(UCloudFile.create(reqItem.newId))) {
                         throw RPCException("File or folder already exists", HttpStatusCode.Conflict)
                     }
                 }
@@ -202,7 +203,8 @@ class FilesController(
             }
 
             for (reqItem in request.items) {
-                if (fileQueries.fileExists(UCloudFile.create(reqItem.id))) {
+                if (reqItem.conflictPolicy == WriteConflictPolicy.REJECT &&
+                    fileQueries.fileExists(UCloudFile.create(reqItem.id))) {
                     throw RPCException("Folder already exists", HttpStatusCode.Conflict)
                 }
             }

--- a/backend/file-ucloud-service/src/jvmMain/kotlin/services/FileQueries.kt
+++ b/backend/file-ucloud-service/src/jvmMain/kotlin/services/FileQueries.kt
@@ -60,6 +60,16 @@ class FileQueries(
         }
     }
 
+    suspend fun fileExists(file: UCloudFile): Boolean {
+        return try {
+            val internalFile = pathConverter.ucloudToInternal(file)
+            nativeFs.stat(internalFile)
+            true
+        } catch (ex: RPCException) {
+            false
+        }
+    }
+
     private suspend fun convertNativeStatToUFile(
         file: InternalFile,
         nativeStat: NativeStat,


### PR DESCRIPTION
Add error message if file/folder already exists when creating a new folder, or when renaming a file/folder.

fixes #3059 