### PR TITLE
Move font-feature-settings into .html {}

### DIFF
--- a/frontend-web/webclient/app/ui-components/GlobalStyle.tsx
+++ b/frontend-web/webclient/app/ui-components/GlobalStyle.tsx
@@ -11,7 +11,6 @@ export function injectFonts(): void {
         
         @font-face {
             font-family: 'Inter';
-            font-feature-settings: "cv05" on, "cv09" on, "cv02" on, "calt" on, "ss03" on;
             src: url('${inter}');
             font-display: swap;
             -webkit-font-smoothing: antialiased;
@@ -161,6 +160,8 @@ html {
     --headerHeight: 48px;
     /* TODO This is not currently enforced in the sidebar */
     --sidebarWidth: 68px;
+
+    font-feature-settings: "cv05" on, "cv09" on, "cv02" on, "calt" on, "ss03" on;
 }
 
 html.light {


### PR DESCRIPTION
Turns out `@font-face { font-feature-settings }` is valid in Firefox and only Firefox. Moved to .html, where it's allowed.