### PR TITLE
Fix for #3154

### DIFF
--- a/frontend-web/webclient/app/Project/Grant/GrantApplicationEditor.tsx
+++ b/frontend-web/webclient/app/Project/Grant/GrantApplicationEditor.tsx
@@ -485,9 +485,13 @@ export const GrantApplicationEditor: (target: RequestTarget) =>
 
         const [isEditingProjectReferenceId, setIsEditingProjectReference] = useState(false);
 
+        const [submitLoading, setSubmissionsLoading] = React.useState(false);
+
         const submitRequest = useCallback(async () => {
+            setSubmissionsLoading(true);
             if (state.targetProject === undefined) {
                 snackbarStore.addFailure("Unknown target. Root level projects cannot apply for more resources.", false);
+                setSubmissionsLoading(false);
                 return;
             }
 
@@ -541,6 +545,7 @@ export const GrantApplicationEditor: (target: RequestTarget) =>
                 state.reload();
                 setIsLocked(true);
             }
+            setSubmissionsLoading(false);
         }, [state.targetProject, state.documentRef, state.recipient, state.productCategories, projectTitleRef,
         state.editingApplication?.id, state.reload]);
 
@@ -776,45 +781,45 @@ export const GrantApplicationEditor: (target: RequestTarget) =>
                                                     <TableCell verticalAlign="top">
                                                         Reference ID
                                                     </TableCell>
-                                                    { state.approver ?
+                                                    {state.approver ?
                                                         <TableCell>
                                                             <table>
                                                                 <tbody>
-                                                                <tr>
-                                                                    {isEditingProjectReferenceId ? (
-                                                                        <>
-                                                                            <td>
-                                                                                <Input
-                                                                                    placeholder={state.editingApplication?.referenceId != null ? state.editingApplication?.referenceId : "e.g. DeiC-SDU-L1-000001"}
-                                                                                    ref={projectReferenceIdRef}
-                                                                                />
-                                                                            </td>
-                                                                            <td>
-                                                                                <Button
-                                                                                    color="blue"
-                                                                                    onClick={updateReferenceID}
-                                                                                    mx="6px"
-                                                                                >
-                                                                                    Update Reference ID
-                                                                                </Button>
-                                                                                <Button
-                                                                                    color="red"
-                                                                                    onClick={cancelEditOfRefId}
-                                                                                >
-                                                                                    Cancel
-                                                                                </Button>
-                                                                            </td>
-                                                                        </>) : (
-                                                                        <>
-                                                                            <td>
-                                                                                {state.editingApplication?.referenceId ?? "No ID given"}
-                                                                            </td>
-                                                                            <td>
-                                                                                <Button ml={"4px"} onClick={() => setIsEditingProjectReference(true)}>Edit</Button>
-                                                                            </td>
-                                                                        </>)
-                                                                    }
-                                                                </tr>
+                                                                    <tr>
+                                                                        {isEditingProjectReferenceId ? (
+                                                                            <>
+                                                                                <td>
+                                                                                    <Input
+                                                                                        placeholder={state.editingApplication?.referenceId != null ? state.editingApplication?.referenceId : "e.g. DeiC-SDU-L1-000001"}
+                                                                                        ref={projectReferenceIdRef}
+                                                                                    />
+                                                                                </td>
+                                                                                <td>
+                                                                                    <Button
+                                                                                        color="blue"
+                                                                                        onClick={updateReferenceID}
+                                                                                        mx="6px"
+                                                                                    >
+                                                                                        Update Reference ID
+                                                                                    </Button>
+                                                                                    <Button
+                                                                                        color="red"
+                                                                                        onClick={cancelEditOfRefId}
+                                                                                    >
+                                                                                        Cancel
+                                                                                    </Button>
+                                                                                </td>
+                                                                            </>) : (
+                                                                            <>
+                                                                                <td>
+                                                                                    {state.editingApplication?.referenceId ?? "No ID given"}
+                                                                                </td>
+                                                                                <td>
+                                                                                    <Button ml={"4px"} onClick={() => setIsEditingProjectReference(true)}>Edit</Button>
+                                                                                </td>
+                                                                            </>)
+                                                                        }
+                                                                    </tr>
                                                                 </tbody>
                                                             </table>
                                                         </TableCell> :
@@ -953,7 +958,7 @@ export const GrantApplicationEditor: (target: RequestTarget) =>
                             </CommentApplicationWrapper>
                             <Box p={32} pb={16}>
                                 {target !== RequestTarget.VIEW_APPLICATION ? (
-                                    <Button disabled={grantFinalized} fullWidth onClick={submitRequest}>
+                                    <Button disabled={grantFinalized || submitLoading} fullWidth onClick={submitRequest}>
                                         Submit Application
                                     </Button>
                                 ) : null


### PR DESCRIPTION
Previously, `loading` was set true when `invokeCommand` was called, which is pretty far down in the `submit`-call. Instead, a different boolean is used, and set right when the call is made, and set to false when the `submit` call terminates in any way.