### PR TITLE
Fix to charge code

### DIFF
--- a/backend/accounting-service/src/jvmMain/resources/db/migration/V27__Issue3248Charge.sql
+++ b/backend/accounting-service/src/jvmMain/resources/db/migration/V27__Issue3248Charge.sql
@@ -1,0 +1,78 @@
+-- noinspection SqlResolve
+create or replace function accounting.charge(
+    requests accounting.charge_request[]
+) returns setof int language plpgsql as $$
+begin
+    -- TODO(Dan): This is currently lacking replay protection
+    perform accounting.process_charge_requests(requests);
+
+    create temporary table failed_charges(request_index int) on commit drop;
+
+    -- NOTE(Dan): Update the balance of every relevant allocation
+    -- NOTE(Dan): We _must_ sum over the local_subtractions. During the update every read of balance will always
+    -- return the same value, thus we would get the wrong results if we don't sum to the total change.
+    with
+        combined_balance_subtractions as (
+            select local_id, sum(local_subtraction) local_subtraction
+            from charge_result
+            group by local_id
+        ),
+        updates as (
+            update accounting.wallet_allocations alloc
+                set balance = balance - local_subtraction
+                from combined_balance_subtractions sub
+                where alloc.id = sub.local_id
+                -- NOTE (HENRIK) balance is changed and should not be subtracted in returning statement
+                returning balance as new_balance, alloc.id as local_id
+        )
+    insert into failed_charges (request_index)
+    select local_request_id
+    from
+        updates u join
+        charge_result c on u.local_id = c.local_id
+    where u.new_balance < 0 and free_to_use != true;
+
+    with
+        combined_local_balance_subtractions as (
+            select local_id, sum(case when leaf_id = local_id then local_subtraction else 0 end) local_subtraction
+            from charge_result
+            group by local_id
+            having sum(case when leaf_id = local_id then local_subtraction else 0 end) != 0
+        ),
+        updates as (
+            update accounting.wallet_allocations alloc
+                set local_balance = local_balance - local_subtraction
+                from combined_local_balance_subtractions sub
+                where alloc.id = sub.local_id
+                -- NOTE (HENRIK) local_balance is changed and should not be subtracted again in returning statement
+                returning local_balance as new_balance, alloc.id as local_id
+        )
+    insert into failed_charges (request_index)
+    select local_request_id
+    from
+        updates u join
+        charge_result c on u.local_id = c.local_id
+    where new_balance < 0 and free_to_use != true;
+
+    delete from ancestor_charges
+    where local_request_id in (select local_request_id from failed_charges);
+
+    insert into accounting.transactions
+    (type, created_at, affected_allocation_id, action_performed_by, change, description,
+     source_allocation_id, product_id, periods, units, transaction_id, initial_transaction_id)
+    select 'charge', now(), res.local_id , res.performed_by, -res.local_subtraction, res.description,
+           res.leaf_id, res.product_id, res.periods, res.units, res.transaction_id, res.transaction_id from leaves_charges res
+    where res.local_subtraction != 0;
+
+    -- NOTE(Dan): Insert a record of every change we did in the transactions table except free to use items
+    insert into accounting.transactions
+    (type, created_at, affected_allocation_id, action_performed_by, change, description,
+     source_allocation_id, product_id, periods, units, transaction_id, initial_transaction_id)
+    select 'charge', now(), res.local_id, res.performed_by, -res.local_subtraction, res.description,
+           res.leaf_id, res.product_id, res.periods, res.units, uuid_generate_v4(), res.transaction_id
+    from ancestor_charges res
+    where free_to_use != true;
+
+    return query select distinct request_index - 1 from failed_charges;
+end;
+$$;

--- a/backend/integration-testing/src/jvmTest/kotlin/backend/Accounting.kt
+++ b/backend/integration-testing/src/jvmTest/kotlin/backend/Accounting.kt
@@ -37,6 +37,7 @@ import dk.sdu.cloud.project.api.Projects
 import dk.sdu.cloud.project.api.TransferPiRoleRequest
 import dk.sdu.cloud.service.PageV2
 import dk.sdu.cloud.service.Time
+import dk.sdu.cloud.service.db.async.sendPreparedStatement
 import dk.sdu.cloud.service.db.async.withSession
 import dk.sdu.cloud.service.test.assertThatInstance
 import dk.sdu.cloud.service.test.assertThatPropertyEquals
@@ -2089,6 +2090,133 @@ class AccountingTest : IntegrationTest() {
                         assertEquals(0, output.wallets[1].allocations[1].balance)
                         assertEquals(0, output.wallets[1].allocations[1].localBalance)
 
+                    }
+                }
+            }
+        }
+   
+        run {
+            class In(
+                val rootBalance: Long,
+                val chainFromRoot: List<Allocation>,
+                val breadth: Int = 1,
+                val chargeAmount: Long = 100,
+                val extraAllocateAndCharge: Boolean = false
+            )
+
+            class Out(
+                val wallets: List<Wallet>
+            )
+
+            test<In, Out>("Charge fix test") {
+                execute {
+                    val leaves = prepareProjectChain(
+                        input.rootBalance, input.chainFromRoot,
+                        sampleStorageDifferential.category, breadth = input.breadth
+                    )
+
+                    val subproject = leaves.first()
+                    val leaf = leaves.last()
+
+                    val request1 = ChargeWalletRequestItem(
+                        leaf.owner,
+                        input.chargeAmount,
+                        1,
+                        sampleStorageDifferential.toReference(),
+                        leaf.username,
+                        "charge of storage",
+                        UUID.randomUUID().toString()
+                    )
+
+                    Accounting.charge.call(bulkRequestOf(request1), serviceClient).orThrow()
+
+                    val request2 = ChargeWalletRequestItem(
+                        leaf.owner,
+                        input.chargeAmount*2,
+                        1,
+                        sampleStorageDifferential.toReference(),
+                        leaf.username,
+                        "charge of storage",
+                        UUID.randomUUID().toString()
+                    )
+
+                    Accounting.charge.call(bulkRequestOf(request2), serviceClient).orThrow()
+
+                    if (input.extraAllocateAndCharge) {
+                        Accounting.deposit.call(
+                            bulkRequestOf(
+                                DepositToWalletRequestItem(
+                                    leaf.owner,
+                                    findWallet(subproject.client, sampleStorageDifferential.category)?.allocations?.first()?.id!!,
+                                    1000L,
+                                    "new deposit",
+                                    transactionId = UUID.randomUUID().toString()
+                                )
+                            ),
+                            subproject.client
+                        )
+
+                        val request3 = ChargeWalletRequestItem(
+                            leaf.owner,
+                            input.chargeAmount*2,
+                            1,
+                            sampleStorageDifferential.toReference(),
+                            leaf.username,
+                            "charge of storage",
+                            UUID.randomUUID().toString()
+                        )
+
+                        Accounting.charge.call(bulkRequestOf(request3), serviceClient).orThrow()
+                    }
+
+                    Out(
+                        leaves.map {
+                            findWallet(it.client, sampleStorageDifferential.category)!!
+                        }
+                    )
+                }
+
+                case("charge twice") {
+                    input(
+                        In(
+                            rootBalance = 10000L,
+                            chainFromRoot = listOf(Allocation(true, 3000L), Allocation(true, 1000L)),
+                            chargeAmount = 100L
+                        )
+                    )
+
+                    check {
+                        assertEquals(800, output.wallets.last().allocations.first().balance)
+                    }
+                }
+
+                case("charge twice - result in overcharge") {
+                    input(
+                        In(
+                            rootBalance = 10000L,
+                            chainFromRoot = listOf(Allocation(true, 1000L), Allocation(true, 1000L)),
+                            chargeAmount = 750L
+                        )
+                    )
+
+                    check {
+                        assertEquals(-500, output.wallets.last().allocations.first().balance)
+                    }
+                }
+
+                case("charge twice - result in overcharge - new alloc and charge again") {
+                    input(
+                        In(
+                            rootBalance = 10000L,
+                            chainFromRoot = listOf(Allocation(true, 1000L), Allocation(true, 1000L)),
+                            chargeAmount = 750L,
+                            extraAllocateAndCharge = true
+                        )
+                    )
+
+                    check {
+                        assertEquals(0, output.wallets.last().allocations.first().balance)
+                        assertEquals(500, output.wallets.last().allocations.last().balance)
                     }
                 }
             }


### PR DESCRIPTION
When charge was checking for failed charges the returning statment of the updates subtracted the needed amount again from the return value. The returning values is using the postupdate values and therefore it would fail once 1/2 of the available resources was required.

Have tested manually
- standard small charge
- charge that would result in negative
- adding new allocation after overchage and making new charge afterwards.

This works as expected both for Differential products and Absolute.

Also made small test suite