### PR TITLE
Improvements and fixes for Syncthing

### DIFF
--- a/frontend-web/webclient/app/Syncthing/Overview.tsx
+++ b/frontend-web/webclient/app/Syncthing/Overview.tsx
@@ -547,6 +547,19 @@ const FolderRenderer: ItemRenderer<SyncthingFolder> = {
         return <>
             <ListRowStat>{prettyPath}</ListRowStat>
         </>
+    },
+
+    ImportantStats: ({resource}) => {
+        // TODO(Brian): Add check for file permissions in folder
+
+        /*return <>
+            <Tooltip tooltipContentWidth="200px" trigger={
+                <Icon name="warning" color="red" />
+            }>
+                You do not have permission to synchronize some files in {resource?.ucloudPath}. These will be ignored.
+            </Tooltip>
+        </>*/
+        return null
     }
 };
 
@@ -660,7 +673,26 @@ const serverOperations: Operation<Job, OperationCallbacks>[] = [
         color: "red",
         enabled: selected => selected.length === 1,
         onClick: (_, cb) => {
-            cb.dispatch({type: "ResetAll"});
+            dialogStore.addDialog(
+                <Box maxWidth={600}>
+                    <Heading.h3>Factory reset Syncthing server?</Heading.h3>
+                    <p>
+                        This will reset the configuration of the Syncthing server completely.
+                        You probably only want to do this if Syncthing is not working, and/or your configuration is broken.
+                    </p>
+                    <p>
+                         All folders and devices will be removed from the Syncthing server.
+                    </p>
+                    <p>
+                         The device ID will no longer be available and should be removed from your local Syncthing devices.
+                         A new device ID will be generated if you decide to set up Synchronization again.
+                    </p>
+                    <Button mr="5px" onClick={() => dialogStore.success()}>Cancel</Button>
+                    <Button color="red" onClick={() => {
+                        cb.dispatch({type: "ResetAll"});
+                        dialogStore.success();
+                    }}>Confirm</Button>
+                </Box>, () => undefined, true);
         }
     },
 ];

--- a/frontend-web/webclient/app/Syncthing/Overview.tsx
+++ b/frontend-web/webclient/app/Syncthing/Overview.tsx
@@ -337,7 +337,7 @@ export const Overview: React.FunctionComponent = () => {
             <FilesBrowse
                 browseType={BrowseType.Embedded}
                 pathRef={pathRef}
-                onSelectRestriction={file => file.status.type === "DIRECTORY"}
+                onSelectRestriction={file => file.status.type === "DIRECTORY" && file.specification.product.id !== "share"}
                 onSelect={async (res) => {
                     const target = removeTrailingSlash(res.id === "" ? pathRef.current : res.id);
                     dispatch({type: "AddFolder", folderPath: target});

--- a/frontend-web/webclient/app/Syncthing/Overview.tsx
+++ b/frontend-web/webclient/app/Syncthing/Overview.tsx
@@ -465,6 +465,7 @@ export const Overview: React.FunctionComponent = () => {
                                     operations={folderOperations}
                                     callbacks={operationCb}
                                     itemTitle={"Folder"}
+                                    disableSelection
                                 />
                             )}
                         </List>
@@ -530,10 +531,13 @@ const FolderRenderer: ItemRenderer<SyncthingFolder> = {
         return <FtIcon fileIcon={{type: "DIRECTORY", ext: ""}} size={size}/>;
     },
 
-    MainTitle: ({resource}) => {
+    MainTitle: ({resource, callbacks}) => {
         if (!resource) return null;
         const prettyPath = usePrettyFilePath(resource?.ucloudPath ?? "/");
-        return <>{fileName(prettyPath)}</>;
+        return <Text cursor="pointer" onClick={() => {
+            const path = resource.ucloudPath;
+            callbacks.history.push(buildQueryString("/files", {path}));
+        }}>{fileName(prettyPath)}</Text>;
     },
 
     Stats: ({resource}) => {
@@ -548,16 +552,7 @@ const FolderRenderer: ItemRenderer<SyncthingFolder> = {
 
 const folderOperations: Operation<SyncthingFolder, OperationCallbacks>[] = [
     {
-        text: "Open folder",
-        icon: "open",
-        enabled: selected => selected.length === 1,
-        onClick: ([file], cb) => {
-            const path = file.ucloudPath;
-            cb.history.push(buildQueryString("/files", {path}));
-        }
-    },
-    {
-        text: "Remove",
+        text: "Remove from Sync",
         icon: "trash",
         color: "red",
         confirm: true,

--- a/frontend-web/webclient/app/Syncthing/Overview.tsx
+++ b/frontend-web/webclient/app/Syncthing/Overview.tsx
@@ -39,6 +39,7 @@ import syncthingScreen1 from "@/Assets/Images/syncthing/syncthing-1.png";
 import syncthingScreen2 from "@/Assets/Images/syncthing/syncthing-2.png";
 import syncthingScreen3 from "@/Assets/Images/syncthing/syncthing-3.png";
 import syncthingScreen4 from "@/Assets/Images/syncthing/syncthing-4.png";
+import {snackbarStore} from "@/Snackbar/SnackbarStore";
 
 // UI state management
 // ================================================================================
@@ -147,9 +148,13 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 
         case "AddFolder": {
             const folders = copy.folders ?? [];
-            folders.push({id: randomUUID(), ucloudPath: action.folderPath});
-            copy.folders = folders;
-            copy.didAddFolder = true;
+            if (folders.map(it => it.ucloudPath).includes(action.folderPath)) {
+                snackbarStore.addFailure("Folder is already added to synchronization", false);
+            } else {
+                folders.push({id: randomUUID(), ucloudPath: action.folderPath});
+                copy.folders = folders;
+                copy.didAddFolder = true;
+            }
             return copy;
         }
 

--- a/frontend-web/webclient/app/UCloud/FilesApi.tsx
+++ b/frontend-web/webclient/app/UCloud/FilesApi.tsx
@@ -823,6 +823,11 @@ function synchronizationOpEnabled(isDir: boolean, files: UFile[], cb: ResourceBr
     const isUCloud = cb.collection?.specification?.product?.provider === "ucloud"
     if (!isUCloud) return false;
 
+    const isShare = cb.collection?.specification.product.id === "share";
+    if (isShare) {
+        return false;
+    }
+
     if (cb.syncthingConfig === undefined) return false;
     if (cb.setSynchronization === undefined) return false;
 

--- a/frontend-web/webclient/app/ui-components/Tooltip.tsx
+++ b/frontend-web/webclient/app/ui-components/Tooltip.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import styled from "styled-components";
 import {SpaceProps} from "styled-system";
-import {Flex, Relative} from "@/ui-components";
+import {Flex} from "@/ui-components";
 import Box, {BoxProps} from "./Box";
 import theme from "./theme";
-import {useCallback, useRef, useState} from "react";
+import {useCallback, useRef} from "react";
 
 interface TooltipContentProps extends BoxProps, SpaceProps {
     bg?: any;
@@ -71,6 +71,14 @@ const Tooltip = (
         if (!tooltip) return;
 
         tooltip.style.left = ev.clientX + "px";
+        
+        if (tooltipContentWidth && parseInt(tooltipContentWidth)) {
+            const parsedWidth = parseInt(tooltipContentWidth);
+            if (ev.clientX + parsedWidth > window.innerWidth) {
+                tooltip.style.left = ev.clientX - parsedWidth + "px";
+            }
+        }
+
         tooltip.style.top = ev.clientY + "px";
         tooltip.style.opacity = "1";
     }, []);

--- a/frontend-web/webclient/package-lock.json
+++ b/frontend-web/webclient/package-lock.json
@@ -5,7 +5,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "ucloud",
             "version": "2022.1.47",
             "dependencies": {
                 "@ginkgo-bioworks/react-json-schema-form-builder": "2.8.0",

--- a/integrated-applications/syncthing/Dockerfile
+++ b/integrated-applications/syncthing/Dockerfile
@@ -12,6 +12,7 @@ RUN tar xzf syncthing.tar.gz
 RUN rm syncthing.tar.gz
 RUN mv syncthing-linux-amd64-v1.19.1 syncthing
 
+RUN useradd --uid 11042 syncthing
 USER 11042
 WORKDIR /
 


### PR DESCRIPTION
 - "Remove" button (for folder) renamed to "Remove from Sync",
 - added warning modal for "Factory reset" button,
 - click on synchronized folder takes you to the folder (+ removed "Open folder" option from folder operations),
 - added user with name "syncthing" to the app container,
 - added warning to synchronized folders which might contain files which isn't sync-able,
 - prevent adding the same folder to Syncthing more than once,
 - hide sync button from shares,
 - prevent adding (incoming) shared folder to sync from the sync ui.
 
fixes #3430
fixes #3433 