### PR TITLE
Minor fixes for IM

### DIFF
--- a/provider-integration/integration-module/build.gradle.kts
+++ b/provider-integration/integration-module/build.gradle.kts
@@ -37,7 +37,7 @@ kotlin {
 
         compilations["main"].dependencies {
             implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.1")
-            implementation("dk.sdu.cloud:integration-module-support:2022.1.52-devel-hippo")
+            implementation("dk.sdu.cloud:integration-module-support:2022.1.54-devel-hippo")
             implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.2.1")
             implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0")
         }

--- a/provider-integration/integration-module/src/nativeMain/kotlin/utils/FileUtils.kt
+++ b/provider-integration/integration-module/src/nativeMain/kotlin/utils/FileUtils.kt
@@ -135,6 +135,11 @@ fun fileExists(path: String): Boolean = memScoped {
     return stat(path, st.ptr) == 0
 }
 
+fun fileIsExecutable(path: String): Boolean = memScoped {
+    val st = alloc<stat>()
+    return stat(path, st.ptr) == 0 && st.st_mode and S_IXUSR.toUInt() != 0u
+}
+
 fun listFiles(internalFile: InternalFile): List<InternalFile> {
     val openedDirectory = try {
         NativeFile.open(internalFile.path, readOnly = true, createIfNeeded = false)

--- a/provider-integration/integration-module/src/nativeMain/kotlin/utils/Terminal.kt
+++ b/provider-integration/integration-module/src/nativeMain/kotlin/utils/Terminal.kt
@@ -2,8 +2,8 @@ package dk.sdu.cloud.utils
 
 class TerminalMessageDsl {
     private val builder: StringBuilder = StringBuilder()
-    private var color = 0
-    private var backgroundColor = 0
+    private var color = 9
+    private var backgroundColor = 9
 
     fun inline(message: String) {
         builder.append(message)

--- a/provider-integration/integration-module/src/nativeMain/kotlin/utils/execv.kt
+++ b/provider-integration/integration-module/src/nativeMain/kotlin/utils/execv.kt
@@ -7,6 +7,7 @@ import kotlinx.cinterop.*
 import platform.posix.*
 import kotlin.system.exitProcess
 import kotlinx.cinterop.ByteVar as KotlinxCinteropByteVar
+import dk.sdu.cloud.service.Loggable
 
 data class ProcessStreams(
     val stdin: Int? = null,
@@ -316,11 +317,23 @@ data class CommandBuilder(
     }
 
     fun executeToText(): ProcessResultText {
+        if (!fileIsExecutable(args[0])) {
+            log.warn("${args[0]} is not executable")
+        }
+
         return startProcessAndCollectToString(args, envs)
     }
 
     fun executeToBinary(): ProcessResult {
+        if (!fileIsExecutable(args[0])) {
+            log.warn("${args[0]} is not executable")
+        }
+
         return startProcessAndCollectToMemory(args, envs)
+    }
+
+    companion object : Loggable {
+        override val log = logger()
     }
 }
 


### PR DESCRIPTION
Fixes #3372
Outputs a warning if attempting to execute a non-executable file (f.x. an extension).

Fixes #3447 
Terminal output falls back to default foreground and background colors instead of black and white.