### PR TITLE
Minor fixes for Syncthing

### DIFF
--- a/frontend-web/webclient/app/Applications/Jobs/Create.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Create.tsx
@@ -83,6 +83,9 @@ export const Create: React.FunctionComponent = () => {
     const jobBeingLoaded = useRef<Partial<JobSpecification> | null>(null);
 
     useEffect(() => {
+        if (appName === "syncthing") {
+            history.push("/syncthing");
+        }
         fetchApplication(UCloud.compute.apps.findByNameAndVersion({appName, appVersion}))
         fetchPrevious(UCloud.compute.apps.findByName({appName}));
     }, [appName, appVersion]);

--- a/frontend-web/webclient/app/Applications/Jobs/View.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/View.tsx
@@ -26,7 +26,7 @@ import {ConfirmationButton} from "@/ui-components/ConfirmationAction";
 import {bulkRequestOf} from "@/DefaultObjects";
 import {api as JobsApi, Job, JobUpdate, JobStatus, ComputeSupport, JobSpecification} from "@/UCloud/JobsApi";
 import {compute} from "@/UCloud";
-import {ProductSupport, ResolvedSupport} from "@/UCloud/ResourceApi";
+import {ResolvedSupport} from "@/UCloud/ResourceApi";
 import AppParameterValueNS = compute.AppParameterValueNS;
 import {costOfDuration, priceExplainer, ProductCompute, usageExplainer} from "@/Accounting";
 import {FilesBrowse} from "@/Files/Files";
@@ -861,7 +861,7 @@ const RunningContent: React.FunctionComponent<{
                             </>
                         }
                         <Box>
-                            <b>Estimated cost per hour: </b>{job.status.resolvedSupport?.product.freeToUse ? "Free" : 
+                            <b>Estimated price per hour: </b>{job.status.resolvedSupport?.product.freeToUse ? "Free" : 
                                 job.status.resolvedProduct ?
                                     usageExplainer(
                                         costOfDuration(60, job.specification.replicas, resolvedProduct),

--- a/frontend-web/webclient/app/Applications/Jobs/View.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/View.tsx
@@ -26,9 +26,9 @@ import {ConfirmationButton} from "@/ui-components/ConfirmationAction";
 import {bulkRequestOf} from "@/DefaultObjects";
 import {api as JobsApi, Job, JobUpdate, JobStatus, ComputeSupport, JobSpecification} from "@/UCloud/JobsApi";
 import {compute} from "@/UCloud";
-import {ResolvedSupport} from "@/UCloud/ResourceApi";
+import {ProductSupport, ResolvedSupport} from "@/UCloud/ResourceApi";
 import AppParameterValueNS = compute.AppParameterValueNS;
-import {priceExplainer, ProductCompute, usageExplainer} from "@/Accounting";
+import {costOfDuration, priceExplainer, ProductCompute, usageExplainer} from "@/Accounting";
 import {FilesBrowse} from "@/Files/Files";
 import {BrowseType} from "@/Resource/BrowseType";
 import {prettyFilePath} from "@/Files/FilePath";
@@ -824,6 +824,8 @@ const RunningContent: React.FunctionComponent<{
         }, 1000);
     });
 
+    const resolvedProduct = job.status.resolvedProduct as unknown as ProductCompute;
+
     return <>
         <RunningInfoWrapper>
             <HighlightedCard color={"purple"} isLoading={false} title={"Job info"} icon={"properties"}>
@@ -858,6 +860,18 @@ const RunningContent: React.FunctionComponent<{
                                 </Box>
                             </>
                         }
+                        <Box>
+                            <b>Estimated cost per hour: </b>{job.status.resolvedSupport?.product.freeToUse ? "Free" : 
+                                job.status.resolvedProduct ?
+                                    usageExplainer(
+                                        costOfDuration(60, job.specification.replicas, resolvedProduct),
+                                        "COMPUTE",
+                                        resolvedProduct.chargeType,
+                                        resolvedProduct.unitOfPrice
+                                    )
+                                : "Unknown"
+                            }
+                        </Box>
 
 
                         <Box flexGrow={1} />

--- a/frontend-web/webclient/app/Syncthing/Overview.tsx
+++ b/frontend-web/webclient/app/Syncthing/Overview.tsx
@@ -431,7 +431,7 @@ export const Overview: React.FunctionComponent = () => {
                     <HighlightedCard
                         className="servers"
                         icon="globeEuropeSolid"
-                        title="Syncthing Servers"
+                        title={folders.length > 1 ? "Syncthing Servers" : "Syncthing Server"}
                         color="blue"
                     >
                         <Text color="darkGray" fontSize={1}>

--- a/integrated-applications/syncthing/src/main/kotlin/syncthing/SyncthingClient.kt
+++ b/integrated-applications/syncthing/src/main/kotlin/syncthing/SyncthingClient.kt
@@ -115,9 +115,16 @@ class SyncthingClient(private val apiKey: String) {
     }
 
     suspend fun configureOptions() {
-        val resp = httpClient.put<HttpResponse>(
+        httpClient.put<HttpResponse>(
             deviceEndpoint("/rest/config/options"),
             apiRequestWithBody(SyncthingOptions())
+        )
+    }
+
+    suspend fun configureGui() {
+        httpClient.patch<HttpResponse>(
+            deviceEndpoint("/rest/config/gui"),
+            apiRequestWithBody(SyncthingGui())
         )
     }
 
@@ -208,19 +215,19 @@ data class SyncthingDefaults(
 
 @Serializable
 data class SyncthingGui(
-    val address: String = "",
-    val apiKey: String = "",
-    val authMode: String = "static",
+    //val address: String = "",
+    //val apiKey: String = "",
+    //val authMode: String = "static",
     val debugging: Boolean = false,
     val enabled: Boolean = true,
-    val insecureAdminAccess: Boolean = false,
-    val insecureAllowFrameLoading: Boolean = false,
-    val insecureSkipHostcheck: Boolean = false,
-    val password: String = "",
-    val theme: String = "default",
-    val unixSocketPermissions: String = "",
-    val useTLS: Boolean = false,
-    val user: String = ""
+    val insecureAdminAccess: Boolean = true,
+    //val insecureAllowFrameLoading: Boolean = false,
+    //val insecureSkipHostcheck: Boolean = false,
+    //val password: String = "",
+    //val theme: String = "default",
+    //val unixSocketPermissions: String = "",
+    //val useTLS: Boolean = false,
+    //val user: String = ""
 )
 
 @Serializable
@@ -267,7 +274,7 @@ data class SyncthingOptions(
     val reconnectionIntervalS: Int = 60,
     val relayReconnectIntervalM: Int = 10,
     val relaysEnabled: Boolean = false,
-    val releasesURL: String = "https://upgrades.syncthing.net/meta.json",
+    val releasesURL: String = "",
     val restartOnWakeup: Boolean = true,
     val sendFullIndexOnUpgrade: Boolean = false,
     val setLowPriority: Boolean = true,

--- a/integrated-applications/syncthing/src/main/kotlin/syncthing/UCloudConfigService.kt
+++ b/integrated-applications/syncthing/src/main/kotlin/syncthing/UCloudConfigService.kt
@@ -93,6 +93,7 @@ class UCloudConfigService(
                             )
                         )
                         syncthingClient.configureOptions()
+                        syncthingClient.configureGui()
                         break
                     } catch (e: Throwable) {
                         // Do nothing

--- a/integrated-applications/syncthing/src/main/kotlin/syncthing/UCloudConfigService.kt
+++ b/integrated-applications/syncthing/src/main/kotlin/syncthing/UCloudConfigService.kt
@@ -94,6 +94,11 @@ class UCloudConfigService(
                         )
                         syncthingClient.configureOptions()
                         syncthingClient.configureGui()
+
+                        // Remove default folder
+                        syncthingClient.removeFolders(
+                            listOf(UCloudSyncthingConfig.Folder("default", ""))
+                        )
                         break
                     } catch (e: Throwable) {
                         // Do nothing


### PR DESCRIPTION
Added price/hour to runs page (fixes #3542)

Redirect to Manage Synchronization-page on open Syncthing-app from App store (fixes #3541)

Remove "Default folder" created by Syncthing on first start (fixes #3540)

Disable password warning in Syncthing GUI by setting `insecureAdminAccess` to true (fixes #3539)

Changed "Syncthing Servers" headline to "Syncthing Server" (singular) if there's only one server (fixes #3536)

Removed "Upgrade" button from Syncthing GUI by removing the `releasesURL` used to check for updates (fixes #3535)