### PR TITLE
Provider/product creation feedback

### DIFF
--- a/frontend-web/webclient/app/Admin/Providers/View.tsx
+++ b/frontend-web/webclient/app/Admin/Providers/View.tsx
@@ -16,6 +16,7 @@ import {
     productTypeToTitle,
     productTypeToJsonType, normalizeBalanceForBackend
 } from "@/Accounting";
+import {snackbarStore} from "@/Snackbar/SnackbarStore";
 
 const normalizedProductTypes: {value: ProductType, title: string}[] =
     allProductTypes.map(value => ({value, title: productTypeToTitle(value)}));
@@ -118,6 +119,13 @@ export const ProductCreationForm: React.FunctionComponent<{provider: Provider, o
                     ...UCloud.accounting.products.createProduct(bulkRequestOf(product as any)),
                     accessTokenOverride: accessToken
                 };
+            }}
+            onSubmitSucceded={(res, data) => {
+                snackbarStore.addSuccess("Product created", false);
+                props.onComplete();
+            }}
+            onSubmitError={(error) => {
+                snackbarStore.addFailure(error, false);
             }}
         >
             <Grid gridTemplateColumns={"1fr"} gridGap={"32px"}>

--- a/frontend-web/webclient/app/Products/CreateProduct.tsx
+++ b/frontend-web/webclient/app/Products/CreateProduct.tsx
@@ -104,6 +104,7 @@ export default abstract class ResourceForm<Request, Response> extends React.Comp
     title: string;
     formatError?: (errors: string[]) => string;
     onSubmitSucceded?: (res: Response, d: DataType) => void;
+    onSubmitError?: (err: string) => void;
 }> {
     public data: DataType = {required: [], fields: {}};
 
@@ -114,12 +115,18 @@ export default abstract class ResourceForm<Request, Response> extends React.Comp
     private async onSubmit(): Promise<void> {
         const validated = this.validate();
         if (validated) {
+            if (this.data.fields.freeToUse) {
+                // Required if freeToUse is true
+                this.data.fields.pricePerUnit = 0.000001;
+            }
+
             const request = await this.props.createRequest(this.data);
             try {
                 const res = await callAPI<Response>(request);
                 this.props.onSubmitSucceded?.(res, this.data);
             } catch (err) {
-                errorMessageOrDefault(err, "Failed to create " + this.props.title.toLocaleLowerCase());
+                const message = errorMessageOrDefault(err, "Failed to create " + this.props.title.toLocaleLowerCase());
+                this.props.onSubmitError?.(message);
             }
         }
     }

--- a/frontend-web/webclient/app/UCloud/ProvidersApi.tsx
+++ b/frontend-web/webclient/app/UCloud/ProvidersApi.tsx
@@ -215,8 +215,10 @@ class ProviderApi extends ResourceApi<Provider, Product, ProviderSpecification, 
             if (resource == null) return null;
             return <>
                 <ListRowStat icon={"grant"}>
-                    {normalizeBalanceForFrontend(resource.pricePerUnit, resource.productType, resource.chargeType, resource.unitOfPrice, true)}
-                    {explainPrice(resource.productType, resource.chargeType, resource.unitOfPrice)}
+                    {resource.freeToUse ? "Free to use" :
+                        normalizeBalanceForFrontend(resource.pricePerUnit, resource.productType, resource.chargeType, resource.unitOfPrice, true) +
+                        explainPrice(resource.productType, resource.chargeType, resource.unitOfPrice)
+                    }
                 </ListRowStat>
             </>;
         }


### PR DESCRIPTION
fixes #3547 

There's possibly merge conflicts with #3503

Minor improvements to product creation feedback:

 - Show error messages as snackbar
 - Close "creation" page on success (go back to product overview)
 - If `freeToUse` is set, automatically set the `pricePerUnit` of the request to 1 credit (which is required by the backend)
 - Display "Free for use" instead of price in list of products, if the product is free.