### PR TITLE
Product/category parameter for retrieveUtilization

### DIFF
--- a/backend/app-kubernetes-service/src/jvmMain/kotlin/rpc/AppKubernetesController.kt
+++ b/backend/app-kubernetes-service/src/jvmMain/kotlin/rpc/AppKubernetesController.kt
@@ -144,9 +144,9 @@ class AppKubernetesController(
 
         implement(computeApi.retrieveUtilization) {
             ok(JobsProviderUtilizationResponse(
-                utilizationService.retrieveCapacity(),
-                utilizationService.retrieveUsedCapacity(),
-                utilizationService.retrieveQueueStatus()
+                utilizationService.retrieveCapacity(request.categoryId),
+                utilizationService.retrieveUsedCapacity(request.categoryId),
+                utilizationService.retrieveQueueStatus(request.categoryId)
             ))
         }
 

--- a/backend/app-orchestrator-service/api/src/commonMain/kotlin/JobsProvider.kt
+++ b/backend/app-orchestrator-service/api/src/commonMain/kotlin/JobsProvider.kt
@@ -159,7 +159,10 @@ data class JobsProviderOpenInteractiveSessionRequestItem(
 
 typealias JobsProviderOpenInteractiveSessionResponse = BulkResponse<OpenSession?>
 
-typealias JobsProviderUtilizationRequest = Unit
+@Serializable
+data class JobsProviderUtilizationRequest(
+    val categoryId: String
+)
 
 typealias JobsProviderUtilizationResponse = JobsRetrieveUtilizationResponse
 

--- a/backend/app-orchestrator-service/src/jvmMain/kotlin/services/JobOrchestrator.kt
+++ b/backend/app-orchestrator-service/src/jvmMain/kotlin/services/JobOrchestrator.kt
@@ -827,7 +827,6 @@ class JobOrchestrator(
         actorAndProject: ActorAndProject,
         request: JobsRetrieveUtilizationRequest
     ): JobsRetrieveUtilizationResponse {
-        JobsRetrieveUtilizationResponse
         return proxy.proxy(
             actorAndProject,
             request,
@@ -874,8 +873,8 @@ class JobOrchestrator(
                 override suspend fun beforeCall(
                     provider: String,
                     resource: RequestWithRefOrResource<JobsRetrieveUtilizationRequest, Job>
-                ) {
-                    // Empty
+                ): JobsProviderUtilizationRequest {
+                    return JobsProviderUtilizationRequest(resource.second.reference.category)
                 }
             }
         )


### PR DESCRIPTION
Updates `UtilizationService` methods to take a product parameter, returning queue status, capacity and usage of nodes flagged with that product only (instead of the whole cluster). In case no nodes is found, the service will return for the whole cluster (as before).

The call from app-orchestrator have been updated to send the name of the product category.

fixes #2425 