### PR TITLE
Fixes #3615

### DIFF
--- a/frontend-web/webclient/app/Project/ProjectSettings.tsx
+++ b/frontend-web/webclient/app/Project/ProjectSettings.tsx
@@ -78,7 +78,7 @@ enum SettingsPage {
 const PageTab: React.FunctionComponent<{
     page: SettingsPage,
     title: string,
-    activePage: SettingsPage
+    activePage: SettingsPage;
 }> = ({page, title, activePage}) => {
     return <SelectableText mr={"1em"} fontSize={3} selected={activePage === page}>
         <Link to={`/project/settings/${page}`}>
@@ -90,7 +90,7 @@ const PageTab: React.FunctionComponent<{
 export const ProjectSettings: React.FunctionComponent = () => {
     const {projectId, projectRole, projectDetails, projectDetailsParams, fetchProjectDetails, reloadProjectStatus} =
         useProjectManagementStatus({isRootComponent: true});
-    const params = useParams<{page?: SettingsPage}>();
+    const params = useParams<{page?: SettingsPage;}>();
     const page = params.page ?? SettingsPage.AVAILABILITY;
 
     useTitle("Project Settings");
@@ -187,9 +187,8 @@ export const ChangeProjectTitle: React.FC<ChangeProjectTitleProps> = props => {
     );
 
     useEffect(() => {
-        setAllowRenaming(getRenamingStatus({projectId: props.projectId}))
-        if (newProjectTitle.current)
-            newProjectTitle.current.value = props.projectDetails.title;
+        setAllowRenaming(getRenamingStatusForSubProject({projectId: props.projectId}));
+        if (newProjectTitle.current) newProjectTitle.current.value = props.projectDetails.title;
     }, [props.projectId, props.projectDetails]);
 
     return (
@@ -259,7 +258,7 @@ export const ChangeProjectTitle: React.FC<ChangeProjectTitleProps> = props => {
 
 interface AllowRenamingProps {
     projectId: string;
-    projectRole: ProjectRole
+    projectRole: ProjectRole;
     setLoading: (loading: boolean) => void;
 }
 
@@ -337,8 +336,8 @@ const SubprojectSettings: React.FC<AllowRenamingProps> = props => {
                 </Box>
             </ActionBox>
         )}
-    </>
-}
+    </>;
+};
 
 
 interface ArchiveSingleProjectProps {
@@ -417,7 +416,7 @@ export const ArchiveSingleProject: React.FC<ArchiveSingleProjectProps> = props =
 };
 
 interface ArchiveProjectProps {
-    projects: UserInProject[]
+    projects: UserInProject[];
     onSuccess: () => void;
 }
 

--- a/frontend-web/webclient/app/Project/SubprojectList.tsx
+++ b/frontend-web/webclient/app/Project/SubprojectList.tsx
@@ -4,7 +4,7 @@ import {useTitle} from "@/Navigation/Redux/StatusActions";
 import {getQueryParamOrElse} from "@/Utilities/URIUtilities";
 import {useHistory, useLocation} from "react-router";
 import {Box, Button, ButtonGroup, Flex, Icon, Input, Text, Tooltip} from "@/ui-components";
-import {createProject, setProjectArchiveStatus, listSubprojects, renameProject, MemberInProject, ProjectRole, projectRoleToStringIcon, projectRoleToString, useProjectId, viewProject, UserInProject, emptyUserInProject} from ".";
+import {createProject, setProjectArchiveStatus, listSubprojects, renameProject, MemberInProject, ProjectRole, projectRoleToStringIcon, projectRoleToString, useProjectId, viewProject, UserInProject, emptyUserInProject, useProjectManagementStatus} from ".";
 import List, {ListRow, ListRowStat} from "@/ui-components/List";
 import {errorMessageOrDefault, preventDefault, stopPropagationAndPreventDefault} from "@/UtilityFunctions";
 import {Operations, Operation} from "@/ui-components/Operation";
@@ -26,6 +26,7 @@ interface MemberInProjectCallbacks {
     startRename: (id: string) => void;
     history: History;
     setActiveProject: (id: string, title: string) => void;
+    isAdminOrPIForParent: boolean;
 }
 
 type ProjectOperation = Operation<MemberInProject, MemberInProjectCallbacks>;
@@ -72,12 +73,12 @@ const subprojectsRenderer: ItemRenderer<MemberInProject, MemberInProjectCallback
             >
                 <Text fontSize={2}>{projectRoleToString(resource.role)}</Text>
             </Tooltip> : null}
-        </>
+        </>;
     },
     Stats({resource}) {
         return <ListRowStat>{resource?.project.fullPath}</ListRowStat>;
     }
-}
+};
 
 const projectOperations: ProjectOperation[] = [
     {
@@ -107,12 +108,12 @@ const projectOperations: ProjectOperation[] = [
         icon: "tags"
     },
     {
-        enabled: (selected) => {
+        enabled: (selected, extras) => {
             if (selected.length !== 1) return false;
-            if (isAdminOrPI(selected[0].role ?? ProjectRole.USER)) {
+            if (extras.isAdminOrPIForParent || isAdminOrPI(selected[0].role ?? ProjectRole.USER)) {
                 return true;
             } else {
-                return "Only Admins and PIs can rename."
+                return "Only Admins and PIs can rename.";
             }
         },
         onClick: ([{project}], extras) => extras.startRename(project.id),
@@ -126,11 +127,12 @@ export default function SubprojectList(): JSX.Element | null {
     const location = useLocation();
     const subprojectFromQuery = getQueryParamOrElse(location.search, "subproject", "");
     const history = useHistory();
-    const [overrideRedirect, setOverride] = React.useState(false)
+    const [overrideRedirect, setOverride] = React.useState(false);
 
-    const projectId = useProjectId();
-
-    React.useEffect(() => {if (!overrideRedirect) history.push(`/subprojects?subproject=${projectId}`)}, [projectId, overrideRedirect]);
+    const project = useProjectManagementStatus({isRootComponent: true});
+    const {projectId, projectRole} = project;
+    
+    React.useEffect(() => {if (!overrideRedirect) history.push(`/subprojects?subproject=${projectId}`);}, [projectId, overrideRedirect]);
 
     const dispatch = useDispatch();
     const setProject = React.useCallback((id: string, title: string) => {
@@ -224,7 +226,7 @@ export default function SubprojectList(): JSX.Element | null {
                 next,
             }),
             projectOverride: subprojectFromQuery
-        })
+        });
     }, [subprojectFromQuery]);
 
     const extra: MemberInProjectCallbacks = {
@@ -232,7 +234,8 @@ export default function SubprojectList(): JSX.Element | null {
         history,
         onSetArchivedStatus,
         startRename: setRenameId,
-        setActiveProject: setProject
+        setActiveProject: setProject,
+        isAdminOrPIForParent: isAdminOrPI(projectRole),
     };
 
     const [subproject, fetchSubproject] = useCloudAPI<UserInProject>({noop: true}, emptyUserInProject(subprojectFromQuery));
@@ -289,7 +292,7 @@ export default function SubprojectList(): JSX.Element | null {
                         right={null}
                     /> : null}
                 {items.map(it => it.project.id === renameId ? (
-                    <form key={it.project.id} onSubmit={e => {stopPropagationAndPreventDefault(e); onRenameProject(it.project.id)}}>
+                    <form key={it.project.id} onSubmit={e => {stopPropagationAndPreventDefault(e); onRenameProject(it.project.id);}}>
                         <Flex height="56px">
                             <Icon mx="8px" mt="17.3px" color={"iconColor"} color2={"iconColor2"} name="projects" />
                             <ButtonGroup height="36px" mt="8px">
@@ -312,6 +315,6 @@ export default function SubprojectList(): JSX.Element | null {
                     />
                 ))}
             </List>
-        )
+        );
     }
 }

--- a/frontend-web/webclient/app/Project/cache.ts
+++ b/frontend-web/webclient/app/Project/cache.ts
@@ -4,7 +4,7 @@
 import {userProjectStatus, UserStatusResponse} from "@/Project";
 import {useGlobal} from "@/Utilities/ReduxHooks";
 import {useCallback} from "react";
-import {useAsyncCommand} from "@/Authentication/DataHook";
+import {useCloudCommand} from "@/Authentication/DataHook";
 
 // This needs to be global
 let cacheIsLoading = false;
@@ -15,7 +15,7 @@ export function useProjectStatus(): ProjectStatus {
         {expiresAt: 0, status: {groups: [], membership: []}}
     );
 
-    const [, invokeCommand] = useAsyncCommand();
+    const [, invokeCommand] = useCloudCommand();
 
     const reload = useCallback(async () => {
         if (cacheIsLoading) return;

--- a/frontend-web/webclient/package-lock.json
+++ b/frontend-web/webclient/package-lock.json
@@ -5,20 +5,18 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "ucloud",
             "version": "2022.2.2",
             "dependencies": {
                 "@ginkgo-bioworks/react-json-schema-form-builder": "2.9.1",
                 "@novnc/novnc": "1.3.0",
                 "@rjsf/core": "^4.2.3",
                 "@svgr/cli": "6.3.1",
-                "@types/jsrsasign": "^10.5.2",
                 "assert": "2.0.0",
                 "big-json-viewer": "^0.1.7",
                 "date-fns": "2.29.1",
                 "fast-deep-equal": "3.1.3",
                 "fuse.js": "6.6.2",
-                "jsrsasign": "^10.5.26",
+                "jsrsasign": "^10.5.27",
                 "localforage": "1.10.0",
                 "path-browserify": "1.0.1",
                 "react": "17.0.2",
@@ -45,6 +43,7 @@
             "devDependencies": {
                 "@types/history": "5.0.0",
                 "@types/json-schema": "7.0.11",
+                "@types/jsrsasign": "^10.5.2",
                 "@types/react": "17.0.43",
                 "@types/react-datepicker": "4.4.2",
                 "@types/react-dom": "17.0.14",
@@ -62,7 +61,7 @@
                 "redux-devtools-extension": "2.13.9",
                 "ts-loader": "9.3.1",
                 "typescript": "4.7.4",
-                "vite": "3.0.8"
+                "vite": "3.0.9"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1465,7 +1464,8 @@
         "node_modules/@types/jsrsasign": {
             "version": "10.5.2",
             "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.2.tgz",
-            "integrity": "sha512-oroCALq37fnUKPRYatawNq3oBNITN7lROpy6JBUanYLhuMZwG5shVxCyZ1/wM3RQCNJ/Ac5/+g7yZaZ+tVBy3A=="
+            "integrity": "sha512-oroCALq37fnUKPRYatawNq3oBNITN7lROpy6JBUanYLhuMZwG5shVxCyZ1/wM3RQCNJ/Ac5/+g7yZaZ+tVBy3A==",
+            "dev": true
         },
         "node_modules/@types/mdast": {
             "version": "3.0.10",
@@ -4490,9 +4490,9 @@
             }
         },
         "node_modules/jsrsasign": {
-            "version": "10.5.26",
-            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.26.tgz",
-            "integrity": "sha512-TjEu1yPdI+8whpe6CA/6XNb7U1sm9+PUItOUfSThOLvx7JCfYHIfuvZK2Egz2DWUKioafn98LPuk+geLGckxMg==",
+            "version": "10.5.27",
+            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.27.tgz",
+            "integrity": "sha512-1F4LmDeJZHYwoVvB44jEo2uZL3XuwYNzXCDOu53Ui6vqofGQ/gCYDmaxfVZtN0TGd92UKXr/BONcfrPonUIcQQ==",
             "funding": {
                 "url": "https://github.com/kjur/jsrsasign#donations"
             }
@@ -7521,9 +7521,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.8.tgz",
-            "integrity": "sha512-AOZ4eN7mrkJiOLuw8IA7piS4IdOQyQCA81GxGsAQvAZzMRi9ZwGB3TOaYsj4uLAWK46T5L4AfQ6InNGlxX30IQ==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.9.tgz",
+            "integrity": "sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.14.47",
@@ -8859,7 +8859,8 @@
         "@types/jsrsasign": {
             "version": "10.5.2",
             "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.2.tgz",
-            "integrity": "sha512-oroCALq37fnUKPRYatawNq3oBNITN7lROpy6JBUanYLhuMZwG5shVxCyZ1/wM3RQCNJ/Ac5/+g7yZaZ+tVBy3A=="
+            "integrity": "sha512-oroCALq37fnUKPRYatawNq3oBNITN7lROpy6JBUanYLhuMZwG5shVxCyZ1/wM3RQCNJ/Ac5/+g7yZaZ+tVBy3A==",
+            "dev": true
         },
         "@types/mdast": {
             "version": "3.0.10",
@@ -11092,9 +11093,9 @@
             "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg=="
         },
         "jsrsasign": {
-            "version": "10.5.26",
-            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.26.tgz",
-            "integrity": "sha512-TjEu1yPdI+8whpe6CA/6XNb7U1sm9+PUItOUfSThOLvx7JCfYHIfuvZK2Egz2DWUKioafn98LPuk+geLGckxMg=="
+            "version": "10.5.27",
+            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.27.tgz",
+            "integrity": "sha512-1F4LmDeJZHYwoVvB44jEo2uZL3XuwYNzXCDOu53Ui6vqofGQ/gCYDmaxfVZtN0TGd92UKXr/BONcfrPonUIcQQ=="
         },
         "jss": {
             "version": "10.8.2",
@@ -13242,9 +13243,9 @@
             }
         },
         "vite": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.8.tgz",
-            "integrity": "sha512-AOZ4eN7mrkJiOLuw8IA7piS4IdOQyQCA81GxGsAQvAZzMRi9ZwGB3TOaYsj4uLAWK46T5L4AfQ6InNGlxX30IQ==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.9.tgz",
+            "integrity": "sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==",
             "dev": true,
             "requires": {
                 "esbuild": "^0.14.47",

--- a/frontend-web/webclient/package.json
+++ b/frontend-web/webclient/package.json
@@ -24,7 +24,7 @@
         "date-fns": "2.29.1",
         "fast-deep-equal": "3.1.3",
         "fuse.js": "6.6.2",
-        "jsrsasign": "^10.5.26",
+        "jsrsasign": "^10.5.27",
         "localforage": "1.10.0",
         "path-browserify": "1.0.1",
         "react": "17.0.2",
@@ -69,6 +69,6 @@
         "redux-devtools-extension": "2.13.9",
         "ts-loader": "9.3.1",
         "typescript": "4.7.4",
-        "vite": "3.0.8"
+        "vite": "3.0.9"
     }
 }


### PR DESCRIPTION
Changes:

```
setAllowRenaming(getRenamingStatus({projectId: props.projectId}))
```
to
```
setAllowRenaming(getRenamingStatusForSubProject({projectId: props.projectId}));
```
for ProjectManagement page

and  adds an isAdminOrPI check for currently active project. I'm not sure that the right side of the predicate event makes sense to have on the SubprojectList page.
```
enabled: (selected, extras) => {
    if (selected.length !== 1) return false;
    if (extras.isAdminOrPIForParent || isAdminOrPI(selected[0].role ?? ProjectRole.USER)) {
            return true;
    } else {
        return "Only Admins and PIs can rename.";
    }
}
```