### PR TITLE
Accounting for Posix plugin (non-quota)

### DIFF
--- a/provider-integration/integration-module/src/main/kotlin/config/VerifiedConfig.kt
+++ b/provider-integration/integration-module/src/main/kotlin/config/VerifiedConfig.kt
@@ -746,6 +746,11 @@ private fun <Cfg : ConfigSchema.Plugins.ProductBased> loadProductBasedPlugins(
                 "launchRealUserInstances is false but not supported for this plugin: ${plugin.pluginTitle}"
             )
         }
+
+        if (plugin.pluginTitle == "Posix" && pluginProducts.size > 1) {
+            emitError("Plugin ${plugin.pluginTitle} supports only 1 product but multiple are specified")
+        }
+
         plugin.configure(pluginConfig)
         result[id] = plugin
     }

--- a/provider-integration/integration-module/src/main/kotlin/plugins/storage/posix/PosixCollectionPlugin.kt
+++ b/provider-integration/integration-module/src/main/kotlin/plugins/storage/posix/PosixCollectionPlugin.kt
@@ -54,12 +54,6 @@ class PosixCollectionPlugin : FileCollectionPlugin {
     )
 
     override fun configure(config: ConfigSchema.Plugins.FileCollections) {
-        // TODO(Brian)
-        /*if (productAllocationResolved.size > 1) {
-            println("This is bad")
-        }
-         */
-
         this.pluginConfig = config as ConfigSchema.Plugins.FileCollections.Posix
     }
 

--- a/provider-integration/integration-module/src/main/kotlin/plugins/storage/posix/PosixCollectionPlugin.kt
+++ b/provider-integration/integration-module/src/main/kotlin/plugins/storage/posix/PosixCollectionPlugin.kt
@@ -19,7 +19,6 @@ import dk.sdu.cloud.plugins.*
 import dk.sdu.cloud.plugins.storage.PathConverter
 import dk.sdu.cloud.service.Loggable
 import dk.sdu.cloud.service.Time
-import dk.sdu.cloud.sql.DBContext
 import dk.sdu.cloud.sql.useAndInvoke
 import dk.sdu.cloud.sql.useAndInvokeAndDiscard
 import dk.sdu.cloud.sql.withSession
@@ -35,6 +34,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import java.text.SimpleDateFormat
+import java.util.Date
+import kotlin.math.floor
 
 class PosixCollectionPlugin : FileCollectionPlugin {
     override val pluginTitle: String = "Posix"
@@ -45,7 +46,19 @@ class PosixCollectionPlugin : FileCollectionPlugin {
     private var initializedProjects = HashMap<ResourceOwnerWithId, List<PathConverter.Collection>>()
     private val mutex = Mutex()
 
+    private data class CollectionChargeCredits(
+        val lastCharged: Date,
+        val priceUnit: ProductPriceUnit,
+        val resourceChargeCredits: ResourceChargeCredits
+    )
+
     override fun configure(config: ConfigSchema.Plugins.FileCollections) {
+        // TODO(Brian)
+        /*if (productAllocationResolved.size > 1) {
+            println("This is bad")
+        }
+         */
+
         this.pluginConfig = config as ConfigSchema.Plugins.FileCollections.Posix
     }
 
@@ -120,24 +133,50 @@ class PosixCollectionPlugin : FileCollectionPlugin {
         })
     }
 
-    private suspend fun ArrayList<ResourceChargeCredits>.sendBatch(client: AuthenticatedClient, db: DBContext) {
-        val filteredBatch = this.filter { it.periods > 0 }
+    private suspend fun ArrayList<CollectionChargeCredits>.sendBatch(client: AuthenticatedClient) {
+        val dateFormatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+        val filteredBatch = this.filter { it.resourceChargeCredits.periods > 0 }
         if (filteredBatch.isEmpty()) return
-        FileCollectionsControl.chargeCredits.call(BulkRequest(filteredBatch), client).orThrow()
 
-        // TODO(Brian): Bad code coming up. Can be more easily improved with Postgres.
-        // NOTE(Brian): Add or update date and time of last scan (read: last charge) for each resource.
-        db.withSession { session ->
-            filteredBatch.forEach {
+        FileCollectionsControl.chargeCredits.call(
+            BulkRequest(filteredBatch.map { it.resourceChargeCredits }),
+            client
+        ).orThrow()
+
+        // NOTE(Brian): Add/update the date and time of the end of the calculated period for each resource.
+        // Charging is only for whole periods, but scans might happen at irregular intervals. By saving the time of the
+        // end of the last charged period, the following scans will eventually make up for fraction-periods not included
+        // in the first charge.
+        dbConnection.withSession { session ->
+            // NOTE(Brian): Can possibly be improved significantly with Postgres
+            this.forEach {
+                val periodFraction = calculatePeriods(it.lastCharged, it.priceUnit) - it.resourceChargeCredits.periods
+
+                val periodFractionSeconds: Long = when (it.priceUnit) {
+                    ProductPriceUnit.UNITS_PER_MINUTE, ProductPriceUnit.CREDITS_PER_MINUTE ->
+                        periodFraction * 60
+
+                    ProductPriceUnit.UNITS_PER_HOUR, ProductPriceUnit.CREDITS_PER_HOUR ->
+                        periodFraction * 60 * 60
+
+                    ProductPriceUnit.UNITS_PER_DAY, ProductPriceUnit.CREDITS_PER_DAY ->
+                        periodFraction * 60 * 60 * 24
+
+                    else -> 0
+                }.toLong()
+
+                val lastChargedPeriodEnd = dateFormatter.format(Date(Time.now() - periodFractionSeconds))
+
                 session.prepareStatement(
                 """
                     insert into posix_storage_scan
-                    (id, last_scan) values (:id, datetime())
-                    on conflict (id) do update set last_scan = datetime()
+                    (id, last_charged_period_end) values (:id, :last_charged_period_end)
+                    on conflict (id) do update set last_charged_period_end = :last_charged_period_end
                 """
                 ).useAndInvokeAndDiscard(
                     prepare = {
-                        bindString("id", it.id)
+                        bindString("id", it.resourceChargeCredits.id)
+                        bindString("last_charged_period_end", lastChargedPeriodEnd)
                     }
                 )
             }
@@ -146,12 +185,12 @@ class PosixCollectionPlugin : FileCollectionPlugin {
         clear()
     }
 
-    private suspend fun ArrayList<ResourceChargeCredits>.addToBatch(
+    private suspend fun ArrayList<CollectionChargeCredits>.addToBatch(
         client: AuthenticatedClient,
-        item: ResourceChargeCredits
+        item: CollectionChargeCredits,
     ) {
         add(item)
-        if (size >= 100) sendBatch(client, dbConnection)
+        if (size >= 100) sendBatch(client)
     }
 
     private var nextScan = 0L
@@ -175,22 +214,8 @@ class PosixCollectionPlugin : FileCollectionPlugin {
             if (now >= nextScan) {
                 debugSystem.enterContext("Posix collection monitoring") {
                     var updates = 0
-                    val batchBuilder = ArrayList<ResourceChargeCredits>()
-
-                    val dateFormatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-
-                    val lastScan: MutableMap<String, Long> = HashMap()
-                    dbConnection.withSession { session ->
-                        session.prepareStatement("""
-                            select id, last_scan from posix_storage_scan
-                        """).useAndInvoke(
-                            readRow = {
-                                val productId = it.getString(0)!!
-                                val lastScanTime = it.getString(1)!!
-                                lastScan[productId] = dateFormatter.parse(lastScanTime).time
-                            }
-                        )
-                    }
+                    val batchBuilder = ArrayList<CollectionChargeCredits>()
+                    val lastCharges = lastChargeTimes()
 
                     productCategories.forEachGraal { category ->
                         var next: String? = null
@@ -217,32 +242,32 @@ class PosixCollectionPlugin : FileCollectionPlugin {
                                         pathConverter.internalToUCloud(InternalFile(colls.first().localPath))
                                     )
 
-                                    val periods: Long = if (lastScan.keys.contains(coll.id)) {
-                                        val minutesSinceLastScan = (Time.now() - lastScan[coll.id]!!) / 1000 / 60
-
-                                        when (item.unitOfPrice) {
-                                            ProductPriceUnit.UNITS_PER_MINUTE, ProductPriceUnit.CREDITS_PER_MINUTE ->
-                                                minutesSinceLastScan
-
-                                            ProductPriceUnit.UNITS_PER_HOUR, ProductPriceUnit.CREDITS_PER_HOUR ->
-                                                minutesSinceLastScan / 60
-
-                                            ProductPriceUnit.UNITS_PER_DAY, ProductPriceUnit.CREDITS_PER_DAY ->
-                                                minutesSinceLastScan / 60 / 24
-
-                                            else -> 1
-                                        }
+                                    val periods: Double = if (lastCharges.keys.contains(coll.id)) {
+                                        calculatePeriods(
+                                            lastCharges[coll.id]!!,
+                                            item.unitOfPrice
+                                        )
                                     } else {
-                                        1
+                                        1.0
+                                    }
+
+                                    val lastCharged = if (lastCharges.keys.contains(coll.id)) {
+                                        lastCharges[coll.id]!!
+                                    } else {
+                                        Date(Time.now())
                                     }
 
                                     batchBuilder.addToBatch(
                                         rpcClient,
-                                        ResourceChargeCredits(
-                                            coll.id,
-                                            "$now-${coll.id}",
-                                            unitsUsed,
-                                            periods
+                                        CollectionChargeCredits(
+                                            lastCharged,
+                                            item.unitOfPrice,
+                                            ResourceChargeCredits(
+                                                coll.id,
+                                                 "$now-${coll.id}",
+                                                unitsUsed,
+                                                floor(periods).toLong()
+                                            )
                                         )
                                     )
 
@@ -250,7 +275,7 @@ class PosixCollectionPlugin : FileCollectionPlugin {
                                 }
                             }
 
-                            batchBuilder.sendBatch(rpcClient, dbConnection)
+                            batchBuilder.sendBatch(rpcClient)
 
                             next = summary.next
                             if (next == null) shouldBreak = true
@@ -264,7 +289,8 @@ class PosixCollectionPlugin : FileCollectionPlugin {
                         if (updates == 0) MessageImportance.IMPLEMENTATION_DETAIL
                         else MessageImportance.THIS_IS_NORMAL
                     )
-                    nextScan = now + (1000L * 60 * 60 * 4)
+                    //nextScan = now + (1000L * 60 * 60 * 4)
+                    nextScan = now + (1000L * 60 * 75)
                 }
             }
 
@@ -281,6 +307,45 @@ class PosixCollectionPlugin : FileCollectionPlugin {
             else -> {
                 calculateUsage.invoke(cfg, CalculateUsageRequest(coll.localPath)).bytesUsed
             }
+        }
+    }
+
+    private fun calculatePeriods(lastCharged: Date, priceUnit: ProductPriceUnit): Double {
+        val minutesSinceLastScan = (Time.now() - lastCharged.time) / 1000.0 / 60.0
+
+        return when (priceUnit) {
+            ProductPriceUnit.UNITS_PER_MINUTE, ProductPriceUnit.CREDITS_PER_MINUTE ->
+                minutesSinceLastScan
+
+            ProductPriceUnit.UNITS_PER_HOUR, ProductPriceUnit.CREDITS_PER_HOUR ->
+                minutesSinceLastScan / 60
+
+            ProductPriceUnit.UNITS_PER_DAY, ProductPriceUnit.CREDITS_PER_DAY ->
+                minutesSinceLastScan / 60 / 24
+
+            else -> 1.0
+        }
+    }
+
+    private suspend fun lastChargeTimes(): Map<String, Date> {
+        val dateFormatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+        return dbConnection.withSession { session ->
+            val lastCharges: MutableMap<String, Date> = HashMap()
+            session.prepareStatement(
+                """
+                    select id, last_charged_period_end from posix_storage_scan
+                """
+            ).useAndInvoke(
+                readRow = {
+                    val productId = it.getString(0)
+                    val lastScanTime = it.getString(1)
+
+                    if (!productId.isNullOrBlank() && !lastScanTime.isNullOrBlank()) {
+                        lastCharges[productId] = dateFormatter.parse(lastScanTime)
+                    }
+                }
+            )
+            lastCharges
         }
     }
 

--- a/provider-integration/integration-module/src/main/kotlin/sql/migrations/Index.kt
+++ b/provider-integration/integration-module/src/main/kotlin/sql/migrations/Index.kt
@@ -25,4 +25,5 @@ fun loadMigrations(migrationHandler: MigrationHandler) {
     migrationHandler.addScript(V2__ComputeSessions())
     migrationHandler.addScript(V1__GenericLicenses())
     migrationHandler.addScript(V2__UCloudCompute())
+    migrationHandler.addScript(V1__PosixStorage())
 }

--- a/provider-integration/integration-module/src/main/kotlin/sql/migrations/PosixStorage.kt
+++ b/provider-integration/integration-module/src/main/kotlin/sql/migrations/PosixStorage.kt
@@ -8,7 +8,7 @@ fun V1__PosixStorage() = MigrationScript("V1__PosixStorage") { session ->
         """
             create table posix_storage_scan(
                 id text primary key,
-            	last_scan timestamp not null
+            	last_charged_period_end timestamp not null
             );
         """
     ).useAndInvokeAndDiscard()

--- a/provider-integration/integration-module/src/main/kotlin/sql/migrations/PosixStorage.kt
+++ b/provider-integration/integration-module/src/main/kotlin/sql/migrations/PosixStorage.kt
@@ -1,0 +1,15 @@
+package dk.sdu.cloud.sql.migrations
+
+import dk.sdu.cloud.sql.MigrationScript
+import dk.sdu.cloud.sql.useAndInvokeAndDiscard
+
+fun V1__PosixStorage() = MigrationScript("V1__PosixStorage") { session ->
+    session.prepareStatement(
+        """
+            create table posix_storage_scan(
+                id text primary key,
+            	last_scan timestamp not null
+            );
+        """
+    ).useAndInvokeAndDiscard()
+}


### PR DESCRIPTION
fixes #3661 
fixes #3691 

Corrects accounting for non-quota storage products.

For each charge the Posix plugin will calculate the time of the end of the charged period and save it. The next time the collection is scanned, the number of periods are calculated from this timestamp, the charge is made, and the time of the end of the charge is overwritten.

An example for a non-quota storage resource which is charged hourly, with a filesystem scan every 1.5 hours:

 - First scan: The current timestamp is saved to denote the beginning of the first period.
 - Second scan: The plugin calculates the time between the beginning of the first period and now to be 1 period, makes a charge, and updates the timestamp to be 0.5 hours earlier.
 - Third scan: The plugin calculates the time between the last period and now to be 2 periods, and updates the timestamp to the current time.

If the scan happens more often than the charge frequency, the plugin will not make any charges or updates to the timestamp before reaching a whole period.

If a quota storage product is used the timestamp is still updated on every charge, but the period is always set to 1.

There is a few database transactions which could probably be improved when switching to Postgresql.