### PR TITLE
Remove console logs (I don't think they were being used at all)

### DIFF
--- a/frontend-web/webclient/app/Project/Allocations.tsx
+++ b/frontend-web/webclient/app/Project/Allocations.tsx
@@ -1,4 +1,4 @@
-import {browseWallets, ChargeType, explainAllocation, normalizeBalanceForFrontend, ProductCategoryId, ProductPriceUnit, ProductType, productTypes, productTypeToIcon, usageExplainer, Wallet, WalletAllocation} from "@/Accounting";
+import {browseWallets, ChargeType, explainAllocation, ProductCategoryId, ProductPriceUnit, ProductType, productTypes, productTypeToIcon, usageExplainer, Wallet, WalletAllocation} from "@/Accounting";
 import {apiBrowse, apiSearch, useCloudAPI} from "@/Authentication/DataHook";
 import {emptyPageV2} from "@/DefaultObjects";
 import MainContainer from "@/MainContainer/MainContainer";
@@ -79,10 +79,12 @@ function Allocations(): JSX.Element {
         }));
     }, [setFilters]);
 
-    const reloadPage = useCallback(() => {
+    const reloadPage = useCallback(async () => {
         const projectOverride = isPersonalWorkspace ? undefined : projectId;
-        fetchWallets({...browseWallets({itemsPerPage: 50, ...filters}), projectOverride});
-        fetchAllocations({...browseSubAllocations({itemsPerPage: 250, ...filters}), projectOverride});
+        await Promise.allSettled([
+            fetchWallets({...browseWallets({itemsPerPage: 50, ...filters}), projectOverride}),
+            fetchAllocations({...browseSubAllocations({itemsPerPage: 250, ...filters}), projectOverride})
+        ]);
         setAllocationGeneration(prev => prev + 1);
     }, [filters, projectId]);
 

--- a/frontend-web/webclient/app/Project/Api.tsx
+++ b/frontend-web/webclient/app/Project/Api.tsx
@@ -294,9 +294,13 @@ interface UseProjectFromParams {
     breadcrumbs: {title: string, link?: string}[];
 }
 
-export function useProjectFromParams(pageTitle: string): UseProjectFromParams {
+export function useProjectIdFromParams(): string {
     const params = useParams<{project: string}>();
-    const projectId = params.project ?? "";
+    return params.project ?? "";
+}
+
+export function useProjectFromParams(pageTitle: string): UseProjectFromParams {
+    const projectId = useProjectIdFromParams();
 
     const [projectFromApi, fetchProject] = useCloudAPI<Project | null>({noop: true}, null);
     const isPersonalWorkspace = projectId === "My Workspace"

--- a/frontend-web/webclient/app/Project/SubAllocations.tsx
+++ b/frontend-web/webclient/app/Project/SubAllocations.tsx
@@ -38,7 +38,7 @@ import {AllocationViewer, resultAsPercent, SubAllocation, allocationText} from "
 import {ResourceProgress} from "@/ui-components/ResourcesProgress";
 import {TextSpan} from "@/ui-components/Text";
 import startOfDay from "date-fns/esm/startOfDay";
-import ProjectAPI, {useProjectId} from "@/Project/Api";
+import ProjectAPI, {useProjectIdFromParams} from "@/Project/Api";
 
 function titleForSubAllocation(alloc: SubAllocation): string {
     return rawAllocationTitleInRow(alloc.productCategoryId.name, alloc.productCategoryId.provider) + ` [${getParentAllocationFromSuballocation(alloc)}]`;
@@ -119,7 +119,7 @@ interface Recipient {
 
 function NewRecipients({wallets, ...props}: {wallets: Wallet[]; reload(): void;}): JSX.Element {
     const [newRecipients, setRecipients] = useState<Recipient[]>([]);
-    const projectId = useProjectId();
+    const projectId = useProjectIdFromParams();
 
     const newRecipientId = useRef(0);
 

--- a/frontend-web/webclient/app/Resource/Browse.tsx
+++ b/frontend-web/webclient/app/Resource/Browse.tsx
@@ -28,7 +28,7 @@ import {doNothing, preventDefault, timestampUnixMs, useEffectSkipMount} from "@/
 import {Client} from "@/Authentication/HttpClientInstance";
 import {useSidebarPage} from "@/ui-components/Sidebar";
 import * as Heading from "@/ui-components/Heading";
-import { NavigateFunction, useLocation, useNavigate} from "react-router";
+import {NavigateFunction, useLocation, useNavigate} from "react-router";
 import {EnumFilterWidget, EnumOption, ResourceFilter, StaticPill} from "@/Resource/Filter";
 import {useResourceSearch} from "@/Resource/Search";
 import {getQueryParamOrElse} from "@/Utilities/URIUtilities";
@@ -129,7 +129,7 @@ function getStoredFilters(title: string): Record<string, string> | null {
         } else {
             return null;
         }
-    }  catch (e) {
+    } catch (e) {
         return null;
     }
 }
@@ -177,7 +177,7 @@ export function ResourceBrowse<Res extends Resource, CB = undefined>({
 
     const [inlineInspecting, setInlineInspecting] = useState<Res | null>(null);
     const closeProperties = useCallback(() => setInlineInspecting(null), [setInlineInspecting]);
-    useEffect(() => fetchProductsWithSupport(api.retrieveProducts()), []);
+    useEffect(() => {fetchProductsWithSupport(api.retrieveProducts())}, []);
     const renaming = useRenamingState<Res>(
         () => renamingValue, [renamingValue],
         (a, b) => a.id === b.id, [],
@@ -430,7 +430,7 @@ export function ResourceBrowse<Res extends Resource, CB = undefined>({
                     hasFeature(Feature.PROVIDER_CONNECTION) ?
                         <Tooltip
                             trigger={
-                                <ProviderLogo providerId={resource?.specification?.product?.provider ?? "?"} size={40}/>
+                                <ProviderLogo providerId={resource?.specification?.product?.provider ?? "?"} size={40} />
                             }
                         >
                             This resource is provided by{" "}
@@ -467,8 +467,8 @@ export function ResourceBrowse<Res extends Resource, CB = undefined>({
         }
     }, [props.navigateToChildren, viewProperties]);
 
-    const listItem = useCallback<(p: { style, index, data: Res[], isScrolling?: boolean }) => JSX.Element>(
-        ({ style, index, data }) => {
+    const listItem = useCallback<(p: {style, index, data: Res[], isScrolling?: boolean}) => JSX.Element>(
+        ({style, index, data}) => {
             const it = data[index];
             return <div style={style} className={"list-item"}>
                 <ItemRowMemo
@@ -572,7 +572,7 @@ export function ResourceBrowse<Res extends Resource, CB = undefined>({
                             children={listItem}
                             overscanCount={32}
                         />
-                    )}/>
+                    )} />
                 </div>
             </List>
         </>
@@ -634,14 +634,14 @@ export function ResourceBrowse<Res extends Resource, CB = undefined>({
                 {inlineInspecting ? null :
                     <>
                         <Operations selected={toggleSet.checked.items} location={"SIDEBAR"}
-                                    entityNameSingular={api.title} entityNamePlural={api.titlePlural}
-                                    extra={callbacks} operations={operations}/>
+                            entityNameSingular={api.title} entityNamePlural={api.titlePlural}
+                            extra={callbacks} operations={operations} />
 
                         <ResourceFilter pills={allPills} filterWidgets={api.filterWidgets}
-                                        sortEntries={api.sortEntries} sortDirection={sortDirection}
-                                        onSortUpdated={onSortUpdated} properties={filters} setProperties={setFilters}
-                                        browseType={props.browseType}
-                                        readOnlyProperties={props.additionalFilters}/>
+                            sortEntries={api.sortEntries} sortDirection={sortDirection}
+                            onSortUpdated={onSortUpdated} properties={filters} setProperties={setFilters}
+                            browseType={props.browseType}
+                            readOnlyProperties={props.additionalFilters} />
                     </>
                 }
 


### PR DESCRIPTION
Add async to useCloudAPI. Can now be awaited, but is opt-in. Fixes #3144
Don't update allocationGeneration until backend responded. Fixes #3723
Use correct projectId for new recipients (suballocations). Fixes #3765