### PR TITLE
Unbind ingresses, network ips and licenses on job creation failure + cleanup

### DIFF
--- a/backend/accounting-service/util/src/main/kotlin/ResourceService.kt
+++ b/backend/accounting-service/util/src/main/kotlin/ResourceService.kt
@@ -548,7 +548,6 @@ abstract class ResourceService<
                     cause: Throwable,
                     mappedRequestIfAny: BulkRequest<Res>?
                 ) {
-                    if (true) return
                     if (mappedRequestIfAny != null && shouldCloseEarly) {
                         db.withTransaction { session ->
                             deleteFromDatabaseSkipProvider(

--- a/backend/app-orchestrator-service/src/main/kotlin/services/JobOrchestrator.kt
+++ b/backend/app-orchestrator-service/src/main/kotlin/services/JobOrchestrator.kt
@@ -256,7 +256,28 @@ class JobOrchestrator(
             """
         )
 
-        // Update ingresses?
+        // Update ingresses
+        val ingressIds = resources.flatMap { job ->
+            job.ingressPoints.map {
+                it.id
+            }
+        }
+
+        session.sendPreparedStatement(
+            {
+                setParameter("job_ids", resourceIds)
+                setParameter("ingress_ids", ingressIds)
+            },
+            """
+                update app_orchestrator.ingresses set status_bound_to = (
+                    select array(select unnest(status_bound_to) except select unnest(:job_ids::bigint[]))
+                ) where resource = some(:ingress_ids::bigint[])
+            """
+        )
+
+
+
+
 
         // Delete from job_input_parameters
 

--- a/backend/app-orchestrator-service/src/main/kotlin/services/JobOrchestrator.kt
+++ b/backend/app-orchestrator-service/src/main/kotlin/services/JobOrchestrator.kt
@@ -256,7 +256,17 @@ class JobOrchestrator(
             """
         )
 
-        // Update ingresses
+        session.sendPreparedStatement(
+            {
+                setParameter("job_ids", resourceIds)
+            },
+            """
+                delete from app_orchestrator.job_input_parameters
+                where job_id = some(:job_ids::bigint[])
+            """
+        )
+
+        // update ingresses
         val ingressIds = resources.flatMap { job ->
             job.ingressPoints.map {
                 it.id
@@ -275,13 +285,9 @@ class JobOrchestrator(
             """
         )
 
+        // TODO Update licenses
 
-
-
-
-        // Delete from job_input_parameters
-
-
+        // TODO update network ips
 
         super.deleteSpecification(resourceIds, resources, session)
     }

--- a/backend/app-orchestrator-service/src/main/kotlin/services/JobOrchestrator.kt
+++ b/backend/app-orchestrator-service/src/main/kotlin/services/JobOrchestrator.kt
@@ -241,6 +241,30 @@ class JobOrchestrator(
         }
     }
 
+    override suspend fun deleteSpecification(
+        resourceIds: List<Long>,
+        resources: List<Job>,
+        session: AsyncDBConnection
+    ) {
+        session.sendPreparedStatement(
+            {
+                setParameter("job_ids", resourceIds)
+            },
+            """
+                delete from app_orchestrator.job_resources
+                where job_id = some(:job_ids::bigint[])
+            """
+        )
+
+        // Update ingresses?
+
+        // Delete from job_input_parameters
+
+
+
+        super.deleteSpecification(resourceIds, resources, session)
+    }
+
     suspend fun insertResources(
         idWithSpec: List<Pair<Long, JobSpecification>>,
         resetExistingResources: Boolean = false,


### PR DESCRIPTION
Properly unbind ingresses, network IPs and licenses if the provider fails on creating the job, by removing the job id from `status_bound_to` in the corresponding tables.

This allows using ingresses again if the job fails (fixes #3165)

Also delete anything from `job_input_parameters` and `job_resources` associated with the failed job (fixes #3244).

