### PR TITLE
Update Launcher.kt

### DIFF
--- a/launcher-tool/src/main/kotlin/Launcher.kt
+++ b/launcher-tool/src/main/kotlin/Launcher.kt
@@ -71,9 +71,8 @@ fun main(args: Array<String>) {
 
         val shouldInitializeTestEnvironment = (args.contains("init") && args.contains("--all-providers"))
 
-        isHeadless = shouldInitializeTestEnvironment || (args.contains("env") && args.contains("delete")) ||
-             (args.contains("snapshot") && args.find { it.contains(Regex("^[t][0-9]+\$")) } != null)
-
+        isHeadless = shouldInitializeTestEnvironment || (args.contains("env") && args.contains("delete")) 
+        
         // NOTE(Dan): initCurrentEnvironment() now initializes an environment which is ready. It returns true if the
         // environment is new. This method will override several "environment" global variables, such as the
         // commandFactory and fileFactory.

--- a/launcher-tool/src/main/kotlin/Launcher.kt
+++ b/launcher-tool/src/main/kotlin/Launcher.kt
@@ -72,7 +72,7 @@ fun main(args: Array<String>) {
         val shouldInitializeTestEnvironment = (args.contains("init") && args.contains("--all-providers"))
 
         isHeadless = shouldInitializeTestEnvironment || (args.contains("env") && args.contains("delete")) ||
-             args.contains("snapshot") && args.find { it.contains(Regex("^[t][0-9]+\$")) } != null
+             (args.contains("snapshot") && args.find { it.contains(Regex("^[t][0-9]+\$")) } != null)
 
         // NOTE(Dan): initCurrentEnvironment() now initializes an environment which is ready. It returns true if the
         // environment is new. This method will override several "environment" global variables, such as the


### PR DESCRIPTION
Parenthesis problem. 
Do to missing parenthesis headless mode required a string of format t[0-9] before it would be true. Should be fixed with this addition. Do not know why this worked on initial branch.