### PR TITLE
defaultValue pass by provider + frontend usage of defaultValue

### DIFF
--- a/backend/app-store-service/src/main/kotlin/app/store/api/ApplicationDescription.kt
+++ b/backend/app-store-service/src/main/kotlin/app/store/api/ApplicationDescription.kt
@@ -147,7 +147,7 @@ sealed class ApplicationDescription(val application: String) {
                         when (val value = param.defaultValue) {
                             is String -> continue
                             is Map<*, *> -> {
-                                value["value"] as? String ?: throw ApplicationVerificationException.BadDefaultValue(
+                                value["path"] as? String ?: throw ApplicationVerificationException.BadDefaultValue(
                                     param.name
                                 )
                             }
@@ -440,10 +440,10 @@ sealed class ApplicationDescription(val application: String) {
                             if (param.defaultValue == null) { JsonNull } else {
                                 JsonObject(
                                     mapOf(
-                                        "value" to when(val value = param.defaultValue) {
+                                        "path" to when(val value = param.defaultValue) {
                                             is String -> JsonPrimitive(value)
                                             is Map<*, *> -> {
-                                                val defaultValue = value["value"] as? String ?: error("bad default value")
+                                                val defaultValue = value["path"] as? String ?: error("bad default value")
                                                 JsonPrimitive(defaultValue)
                                             }
                                             else -> error("bad default value")
@@ -462,10 +462,10 @@ sealed class ApplicationDescription(val application: String) {
                             if (param.defaultValue == null) { JsonNull } else {
                                 JsonObject(
                                     mapOf(
-                                        "value" to when(val value = param.defaultValue) {
+                                        "path" to when(val value = param.defaultValue) {
                                             is String -> JsonPrimitive(value)
                                             is Map<*, *> -> {
-                                                val defaultValue = value["value"] as? String ?: error("bad default value")
+                                                val defaultValue = value["path"] as? String ?: error("bad default value")
                                                 JsonPrimitive(defaultValue)
                                             }
                                             else -> error("bad default value")

--- a/frontend-web/webclient/app/Applications/Jobs/Widgets/Bool.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Widgets/Bool.tsx
@@ -12,8 +12,10 @@ interface BoolProps extends WidgetProps {
 
 export const BoolParameter: React.FunctionComponent<BoolProps> = props => {
     const error = props.errors[props.parameter.name] != null;
+    const defaultValue: boolean | undefined = props.parameter.defaultValue != undefined ?
+        (props.parameter.defaultValue as unknown as AppParameterValueNS.Bool).value : undefined;
     return <Flex>
-        <Select id={widgetId(props.parameter)} error={error}>
+        <Select defaultValue={defaultValue?.toString()} id={widgetId(props.parameter)} error={error}>
             <option value={""} />
             <option value="true">{props.parameter.trueValue}</option>
             <option value="false">{props.parameter.falseValue}</option>

--- a/frontend-web/webclient/app/Applications/Jobs/Widgets/Enum.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Widgets/Enum.tsx
@@ -13,8 +13,11 @@ interface EnumProps extends WidgetProps {
 
 export const EnumParameter: React.FunctionComponent<EnumProps> = props => {
     const error = props.errors[props.parameter.name] != null;
+    const defaultValue: string | undefined = props.parameter.defaultValue != undefined ?
+        (props.parameter.defaultValue as unknown as AppParameterValueNS.Text).value : undefined;
+
     return <Flex>
-        <Select id={widgetId(props.parameter)} error={error}>
+        <Select defaultValue={defaultValue} id={widgetId(props.parameter)} error={error}>
             <option value={""} />
             {props.parameter.options.map(it => (
                 <option key={it.value} value={it.value}>{it.name}</option>

--- a/frontend-web/webclient/app/Applications/Jobs/Widgets/GenericText.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Widgets/GenericText.tsx
@@ -3,8 +3,8 @@ import * as UCloud from "@/UCloud";
 import {findElement, widgetId, WidgetProps, WidgetSetter, WidgetValidator} from "./index";
 import {TextArea, Input} from "@/ui-components";
 import {compute} from "@/UCloud";
-import ApplicationParameter = compute.ApplicationParameter;
 import styled from "styled-components";
+import AppParameterValueNS = compute.AppParameterValueNS;
 
 type GenericTextType =
     UCloud.compute.ApplicationParameterNS.Text |
@@ -24,12 +24,53 @@ export const GenericTextParameter: React.FunctionComponent<GenericTextProps> = p
         placeholder = "Number (example 12.34)"
     }
 
+    let defaultValue: AppParameterValueNS.FloatingPoint | AppParameterValueNS.Text | AppParameterValueNS.Integer | undefined = undefined;
+    
+    if (props.parameter.defaultValue != undefined) {
+        if (props.parameter.type === "integer") {
+            defaultValue = props.parameter.defaultValue as unknown as AppParameterValueNS.Integer;
+        } else if (props.parameter.type === "floating_point") {
+            defaultValue = props.parameter.defaultValue as unknown as AppParameterValueNS.FloatingPoint;
+        } else {
+            defaultValue = props.parameter.defaultValue as unknown as AppParameterValueNS.Text;
+        }
+    }
+
     const error = props.errors[props.parameter.name] != null;
-    return <Input
+
+    let elem = <Input
         id={widgetId(props.parameter)}
+        defaultValue={defaultValue?.value}
         placeholder={placeholder}
         error={error}
     />;
+
+    if (props.parameter.type === "integer") {
+        elem = <Input
+            id={widgetId(props.parameter)}
+            type={"number"}
+            defaultValue={defaultValue?.value}
+            min={props.parameter.min}
+            max={props.parameter.max}
+            step={props.parameter.step ?? 1}
+            placeholder={placeholder}
+            error={error}
+        />
+    } else if (props.parameter.type === "floating_point") {
+        elem = <Input
+            id={widgetId(props.parameter)}
+            type={"number"}
+            defaultValue={defaultValue?.value}
+            min={props.parameter.min}
+            max={props.parameter.max}
+            step={props.parameter.step ?? "any"}
+            placeholder={placeholder}
+            error={error}
+        />
+    }
+
+
+    return elem;
 };
 
 const TextAreaApp = styled(TextArea)`

--- a/frontend-web/webclient/app/Applications/Jobs/Widgets/GenericText.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Widgets/GenericText.tsx
@@ -24,6 +24,9 @@ export const GenericTextParameter: React.FunctionComponent<GenericTextProps> = p
         placeholder = "Number (example 12.34)"
     }
 
+    // NOTE(Brian): This is a bit hacky. The defaultValue is not actually sent as a parameter on submit.
+    // If changed, the correct value should be sent as a parameter, and otherwise the backend will
+    // handle the defaultValue.
     let defaultValue: AppParameterValueNS.FloatingPoint | AppParameterValueNS.Text | AppParameterValueNS.Integer | undefined = undefined;
     
     if (props.parameter.defaultValue != undefined) {
@@ -45,6 +48,9 @@ export const GenericTextParameter: React.FunctionComponent<GenericTextProps> = p
         error={error}
     />;
 
+    // NOTE(Brian): The use of input fields of type "number" have previously been removed for
+    // some reason. I have re-added them here, since we don't remember the exact reason for the removal.
+    // If they misbehave we can simply remove the following section.
     if (props.parameter.type === "integer") {
         elem = <Input
             id={widgetId(props.parameter)}

--- a/provider-integration/integration-module/src/main/kotlin/plugins/compute/ucloud/FeatureParameter.kt
+++ b/provider-integration/integration-module/src/main/kotlin/plugins/compute/ucloud/FeatureParameter.kt
@@ -85,11 +85,7 @@ class FeatureParameter(
                 app.parameters.find { it.name == paramName }!! to value
             }.toMap()
 
-        println(givenParameters)
-
         val allParameters = defaultParameters + givenParameters
-
-        println(allParameters)
 
         builder.command(app.invocation.flatMap { parameter ->
             parameter.buildInvocationList(allParameters, builder = argBuilder)


### PR DESCRIPTION
- Default values should be passed correctly by the provider,
- On the frontend:
  - default values should be automatically inserted into the input fields of some parameter types (text, integer, floating_point), and selected automatically in case of enums and booleans,
  - min, max and step should now work correctly for integers and floating_point,
  - entering text in a integer or floating_point parameter field should show that the input is invalid (in firefox) or not be possible at all (chrome).

Marking as draft until the support team have tested the changes + we have discussed whether numeric fields should remain as text-fields or be changed to number fields.

ref #3308 