### PR TITLE
Fixed emails being send multiple times to same receiver

### DIFF
--- a/backend/accounting-service/src/main/kotlin/services/grants/Notifications.kt
+++ b/backend/accounting-service/src/main/kotlin/services/grants/Notifications.kt
@@ -129,7 +129,7 @@ class GrantNotificationService(
             val requestedBy = rows.first().requestedBy
             val projectId = rows.first().projectId
             val grantRecipientTitle = rows.first().grantRecipientTitle
-            val admins = rows.map { it.projectMember }
+            val admins = rows.map { it.projectMember }.toSet()
             val ctx = NotificationContext(title, projectId, requestedBy, grantRecipientTitle,
                 rows.first().grantRecipient)
 


### PR DESCRIPTION
It seems users were receiving multiple identical emails whenever a grant-application was created or updated.

The number of emails send to each user seemed to depend on the number of products applied for (1 email for each product of the application, to each admin).

There might be a better fix, and I suspect the bug is located elsewhere. This PR just ensures that the list of receivers for a notification does not contain duplicates, which seems to fix the problem.