### PR TITLE
Improvements to file preview

### DIFF
--- a/frontend-web/webclient/app/Files/Preview.tsx
+++ b/frontend-web/webclient/app/Files/Preview.tsx
@@ -1,22 +1,21 @@
 import {useCloudCommand} from "@/Authentication/DataHook";
 import * as React from "react";
-import {extensionFromPath, extensionTypeFromPath, isExtPreviewSupported} from "@/UtilityFunctions";
+import {ExtensionType, extensionFromPath, extensionType, getUserThemePreference, isLightThemeStored, languageFromExtension, typeFromMime} from "@/UtilityFunctions";
 import {PredicatedLoadingSpinner} from "@/LoadingIcon/LoadingIcon";
-import {Box, Markdown} from "@/ui-components";
+import {Markdown, theme} from "@/ui-components";
 import {api as FilesApi, FilesCreateDownloadResponseItem, normalizeDownloadEndpoint, UFile} from "@/UCloud/FilesApi";
 import {useEffect, useState} from "react";
 import {fileName} from "@/Utilities/FileUtilities";
 import {bulkRequestOf} from "@/DefaultObjects";
 import {BulkResponse} from "@/UCloud";
-import SyntaxHighlighter from "react-syntax-highlighter";
 import {injectStyle} from "@/Unstyled";
+import fileType from "magic-bytes.js";
+import Editor from "@monaco-editor/react";
 
 export const MAX_PREVIEW_SIZE_IN_BYTES = 50_000_000;
 
 export const FilePreview: React.FunctionComponent<{file: UFile}> = ({file}) => {
-    const extension = extensionFromPath(file.id);
-    const isValidExtension = isExtPreviewSupported(extension);
-    const type = extensionTypeFromPath(file.id);
+    const [type, setType] = useState<ExtensionType>(null);
     const [loading, invokeCommand] = useCloudCommand();
 
     const [data, setData] = useState("");
@@ -25,7 +24,7 @@ export const FilePreview: React.FunctionComponent<{file: UFile}> = ({file}) => {
     const fetchData = React.useCallback(async () => {
         const size = file.status.sizeInBytes;
         if (file.status.type !== "FILE") return;
-        if (!loading && isValidExtension && size != null && size < MAX_PREVIEW_SIZE_IN_BYTES && size > 0) {
+        if (!loading && size != null && size < MAX_PREVIEW_SIZE_IN_BYTES && size > 0) {
             try {
                 const download = await invokeCommand<BulkResponse<FilesCreateDownloadResponseItem>>(
                     FilesApi.createDownload(bulkRequestOf({id: file.id})),
@@ -37,24 +36,43 @@ export const FilePreview: React.FunctionComponent<{file: UFile}> = ({file}) => {
                     return;
                 }
                 const content = await fetch(normalizeDownloadEndpoint(downloadEndpoint));
-                switch (type) {
-                    case "image":
-                    case "audio":
-                    case "video":
-                    case "pdf":
-                        setData(URL.createObjectURL(await content.blob()));
+                const contentBlob = await content.blob();
+                const contentBuffer = new Uint8Array(await contentBlob.arrayBuffer());
+
+                const foundFileType = fileType(contentBuffer);
+                if (foundFileType.length === 0) {
+                    const text = tryDecodeText(contentBuffer);
+                    if (text !== null) {
+                        setType("text");
+                        setData(await contentBlob.text());
                         setError(null);
-                        break;
-                    case "code":
-                    case "text":
-                    case "application":
-                    case "markdown":
-                        setData(await content.text());
-                        setError(null);
-                        break;
-                    default:
-                        setError(`Preview not support for '${extensionFromPath(file.id)}'.`);
-                        break;
+                    } else {
+                        setError("Preview is not supported for this file.");
+                    }
+                } else {
+                    const typeFromFileType = typeFromMime(foundFileType[0].mime ?? "") ?? extensionType(foundFileType[0].typename);
+
+                    switch (typeFromFileType) {
+                        case "image":
+                        case "audio":
+                        case "video":
+                        case "pdf":
+                            setData(URL.createObjectURL(new Blob([contentBlob], {type: foundFileType[0].mime}))); 
+                            setError(null);
+                            break;
+                        case "code":
+                        case "text":
+                        case "application":
+                        case "markdown":
+                            setData(await content.text());
+                            setError(null);
+                            break;
+                        default:
+                            setError(`Preview not supported for '${foundFileType[0].typename}'.`);
+                            break;
+                    }
+
+                    setType(typeFromFileType);
                 }
             } catch (e) {
                 setError("Unable to display preview. Try again later or with a different file.");
@@ -80,12 +98,18 @@ export const FilePreview: React.FunctionComponent<{file: UFile}> = ({file}) => {
     switch (type) {
         case "text":
         case "code":
-            /* Even 100_000 tanks performance. Anything above stalls or kills the sandbox process. */
-            if (file.status.sizeInBytes == null || file.status.sizeInBytes > 100_000) {
-                node = <Box width="100%"><pre className="fullscreen text-preview">{data}</pre></Box>
-            } else {
-                node = <Box width="100%"><SyntaxHighlighter className="fullscreen text-preview">{data}</SyntaxHighlighter></Box>;
-            }
+            node = <Editor
+                height="500px"
+                width="100%"
+                options={{
+                    readOnly: true,
+                    minimap: {enabled: false},
+                }}
+                theme={isLightThemeStored() ? "light" : "vs-dark"}
+                language={languageFromExtension(extensionFromPath(file.id))}
+                className="fullscreen"
+                value={data}
+            />;
             break;
         case "image":
             node = <img alt={fileName(file.id)} src={data} />
@@ -97,7 +121,7 @@ export const FilePreview: React.FunctionComponent<{file: UFile}> = ({file}) => {
             node = <video src={data} controls />;
             break;
         case "pdf":
-            node = <embed style={{width: "100vw", height: "100vh"}} className="fullscreen" src={data} />;
+            node = <object type="application/pdf" style={{width: "100vw", height: "100vh"}} className="fullscreen" data={data} />;
             break;
         case "markdown":
             node = <div><Markdown>{data}</Markdown></div>;
@@ -127,3 +151,12 @@ const ItemWrapperClass = injectStyle("item-wrapper", k => `
       overflow-y: scroll;
     }
 `);
+
+function tryDecodeText(buf: Uint8Array): string | null {
+    try {
+        const d = new TextDecoder("utf-8", { fatal: true });
+        return d.decode(buf);
+    } catch (e) {
+        return null;
+    }
+}

--- a/frontend-web/webclient/app/UtilityFunctions.tsx
+++ b/frontend-web/webclient/app/UtilityFunctions.tsx
@@ -207,7 +207,6 @@ export function extensionType(ext: string): ExtensionType {
         case "avi":
         case "mov":
         case "wmv":
-        case "mkv":
             return "video";
         case "gz":
         case "zip":

--- a/frontend-web/webclient/app/UtilityFunctions.tsx
+++ b/frontend-web/webclient/app/UtilityFunctions.tsx
@@ -78,6 +78,51 @@ export const commonFileExtensions = [
     "dat", "binary", "rs",
 ];
 
+export function languageFromExtension(ext: string): string {
+    const languages = {
+        "md": "markdown",
+        "kt": "kotlin",
+        "kts": "kotlin",
+        "js": "javascript",
+        "jsx": "javascript",
+        "ts": "typescript",
+        "tsx": "typescript",
+        "py": "python",
+        "h": "c",
+        "cc": "c++",
+        "hh": "c++",
+        "h++": "c++",
+        "hpp": "c++",
+        "cpp": "c++",
+        "cxx": "c++",
+        "hxx": "c++",
+        "htm": "html",
+        "lhs": "haskell",
+        "hs": "haskell",
+        "sh": "shell",
+        "bib": "tex",
+        "yml": "yaml",
+        "sbatch": "shell",
+        "rs": "rust"
+    };
+
+    return languages[ext.toLowerCase()] ?? ext.toLowerCase();
+}
+
+export function typeFromMime(mimeType: string): ExtensionType {
+    const mime = mimeType.toLowerCase();
+
+    if (mime.startsWith("video")) {
+        return "video";
+    } else if (mime.startsWith("audio")) {
+        return "audio";
+    } else if (mime.startsWith("image")) {
+        return "image";
+    } else {
+        return null;
+    }
+}
+
 export function extensionType(ext: string): ExtensionType {
     switch (ext.toLowerCase()) {
         case "app":
@@ -162,6 +207,7 @@ export function extensionType(ext: string): ExtensionType {
         case "avi":
         case "mov":
         case "wmv":
+        case "mkv":
             return "video";
         case "gz":
         case "zip":

--- a/frontend-web/webclient/package-lock.json
+++ b/frontend-web/webclient/package-lock.json
@@ -1,7 +1,7 @@
 {
     "name": "ucloud",
     "version": "2024.1.0-dev-1",
-    "lockfileVersion": 3,
+    "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
@@ -9,6 +9,7 @@
             "version": "2024.1.0-dev-1",
             "dependencies": {
                 "@ginkgo-bioworks/react-json-schema-form-builder": "2.10.2",
+                "@monaco-editor/react": "^4.6.0",
                 "@novnc/novnc": "1.4.0",
                 "@rjsf/core": "4.2.3",
                 "@svgr/cli": "5.5.0",
@@ -20,6 +21,7 @@
                 "fuse.js": "6.6.2",
                 "jsrsasign": "10.8.6",
                 "localforage": "1.10.0",
+                "magic-bytes.js": "^1.5.0",
                 "path-browserify": "1.0.1",
                 "react": "18.2.0",
                 "react-apexcharts": "^1.4.1",
@@ -1124,6 +1126,30 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "3.1.0",
                 "@jridgewell/sourcemap-codec": "1.4.14"
+            }
+        },
+        "node_modules/@monaco-editor/loader": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+            "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+            "dependencies": {
+                "state-local": "^1.0.6"
+            },
+            "peerDependencies": {
+                "monaco-editor": ">= 0.21.0 < 1"
+            }
+        },
+        "node_modules/@monaco-editor/react": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+            "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+            "dependencies": {
+                "@monaco-editor/loader": "^1.4.0"
+            },
+            "peerDependencies": {
+                "monaco-editor": ">= 0.25.0 < 1",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/@novnc/novnc": {
@@ -4037,6 +4063,11 @@
                 "node": ">=10"
             }
         },
+        "node_modules/magic-bytes.js": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.5.0.tgz",
+            "integrity": "sha512-wJkXvutRbNWcc37tt5j1HyOK1nosspdh3dj6LUYYAvF6JYNqs53IfRvK9oEpcwiDA1NdoIi64yAMfdivPeVAyw=="
+        },
         "node_modules/mdast-util-definitions": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
@@ -4609,6 +4640,12 @@
             "bin": {
                 "mkdirp": "bin/cmd.js"
             }
+        },
+        "node_modules/monaco-editor": {
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.44.0.tgz",
+            "integrity": "sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q==",
+            "peer": true
         },
         "node_modules/mri": {
             "version": "1.2.0",
@@ -5718,6 +5755,11 @@
             "version": "0.1.8",
             "license": "MIT"
         },
+        "node_modules/state-local": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+            "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
+        },
         "node_modules/string.prototype.trim": {
             "version": "1.2.7",
             "license": "MIT",
@@ -6799,6 +6841,4356 @@
             "engines": {
                 "node": ">= 6"
             }
+        }
+    },
+    "dependencies": {
+        "@ampproject/remapping": {
+            "version": "2.2.1",
+            "requires": {
+                "@jridgewell/gen-mapping": "^0.3.0",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            }
+        },
+        "@babel/code-frame": {
+            "version": "7.22.13",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+            "requires": {
+                "@babel/highlight": "^7.22.13",
+                "chalk": "^2.4.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/compat-data": {
+            "version": "7.22.5"
+        },
+        "@babel/core": {
+            "version": "7.21.4",
+            "requires": {
+                "@ampproject/remapping": "^2.2.0",
+                "@babel/code-frame": "^7.21.4",
+                "@babel/generator": "^7.21.4",
+                "@babel/helper-compilation-targets": "^7.21.4",
+                "@babel/helper-module-transforms": "^7.21.2",
+                "@babel/helpers": "^7.21.0",
+                "@babel/parser": "^7.21.4",
+                "@babel/template": "^7.20.7",
+                "@babel/traverse": "^7.21.4",
+                "@babel/types": "^7.21.4",
+                "convert-source-map": "^1.7.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.2",
+                "semver": "^6.3.0"
+            }
+        },
+        "@babel/generator": {
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+            "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+            "requires": {
+                "@babel/types": "^7.23.0",
+                "@jridgewell/gen-mapping": "^0.3.2",
+                "@jridgewell/trace-mapping": "^0.3.17",
+                "jsesc": "^2.5.1"
+            }
+        },
+        "@babel/helper-compilation-targets": {
+            "version": "7.21.4",
+            "requires": {
+                "@babel/compat-data": "^7.21.4",
+                "@babel/helper-validator-option": "^7.21.0",
+                "browserslist": "^4.21.3",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "5.1.1",
+                    "requires": {
+                        "yallist": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "yallist": {
+                            "version": "3.1.1"
+                        }
+                    }
+                }
+            }
+        },
+        "@babel/helper-environment-visitor": {
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA=="
+        },
+        "@babel/helper-function-name": {
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+            "requires": {
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.22.5",
+            "requires": {
+                "@babel/types": "^7.22.5"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.22.5",
+            "requires": {
+                "@babel/types": "^7.22.5"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.21.2",
+            "requires": {
+                "@babel/helper-environment-visitor": "^7.18.9",
+                "@babel/helper-module-imports": "^7.18.6",
+                "@babel/helper-simple-access": "^7.20.2",
+                "@babel/helper-split-export-declaration": "^7.18.6",
+                "@babel/helper-validator-identifier": "^7.19.1",
+                "@babel/template": "^7.20.7",
+                "@babel/traverse": "^7.21.2",
+                "@babel/types": "^7.21.2"
+            }
+        },
+        "@babel/helper-plugin-utils": {
+            "version": "7.20.2",
+            "dev": true
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.20.2",
+            "requires": {
+                "@babel/types": "^7.20.2"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+            "requires": {
+                "@babel/types": "^7.22.5"
+            }
+        },
+        "@babel/helper-string-parser": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
+        },
+        "@babel/helper-validator-option": {
+            "version": "7.22.5"
+        },
+        "@babel/helpers": {
+            "version": "7.21.0",
+            "requires": {
+                "@babel/template": "^7.20.7",
+                "@babel/traverse": "^7.21.0",
+                "@babel/types": "^7.21.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+            "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "chalk": "^2.4.2",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/parser": {
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+            "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw=="
+        },
+        "@babel/plugin-transform-react-jsx-self": {
+            "version": "7.21.0",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.20.2"
+            }
+        },
+        "@babel/plugin-transform-react-jsx-source": {
+            "version": "7.19.6",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.19.0"
+            }
+        },
+        "@babel/runtime": {
+            "version": "7.21.5",
+            "requires": {
+                "regenerator-runtime": "^0.13.11"
+            }
+        },
+        "@babel/template": {
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+            "requires": {
+                "@babel/code-frame": "^7.22.13",
+                "@babel/parser": "^7.22.15",
+                "@babel/types": "^7.22.15"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+            "requires": {
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/helper-hoist-variables": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/parser": "^7.23.0",
+                "@babel/types": "^7.23.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0"
+            }
+        },
+        "@babel/types": {
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+            "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+            "requires": {
+                "@babel/helper-string-parser": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@emotion/babel-plugin": {
+            "version": "11.11.0",
+            "requires": {
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/runtime": "^7.18.3",
+                "@emotion/hash": "^0.9.1",
+                "@emotion/memoize": "^0.8.1",
+                "@emotion/serialize": "^1.1.2",
+                "babel-plugin-macros": "^3.1.0",
+                "convert-source-map": "^1.5.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-root": "^1.1.0",
+                "source-map": "^0.5.7",
+                "stylis": "4.2.0"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.22.3",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.11"
+                    }
+                },
+                "stylis": {
+                    "version": "4.2.0"
+                }
+            }
+        },
+        "@emotion/cache": {
+            "version": "11.11.0",
+            "requires": {
+                "@emotion/memoize": "^0.8.1",
+                "@emotion/sheet": "^1.2.2",
+                "@emotion/utils": "^1.2.1",
+                "@emotion/weak-memoize": "^0.3.1",
+                "stylis": "4.2.0"
+            },
+            "dependencies": {
+                "stylis": {
+                    "version": "4.2.0"
+                }
+            }
+        },
+        "@emotion/hash": {
+            "version": "0.9.1"
+        },
+        "@emotion/is-prop-valid": {
+            "version": "1.2.1",
+            "requires": {
+                "@emotion/memoize": "^0.8.1"
+            }
+        },
+        "@emotion/memoize": {
+            "version": "0.8.1"
+        },
+        "@emotion/react": {
+            "version": "11.11.0",
+            "requires": {
+                "@babel/runtime": "^7.18.3",
+                "@emotion/babel-plugin": "^11.11.0",
+                "@emotion/cache": "^11.11.0",
+                "@emotion/serialize": "^1.1.2",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+                "@emotion/utils": "^1.2.1",
+                "@emotion/weak-memoize": "^0.3.1",
+                "hoist-non-react-statics": "^3.3.1"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.22.3",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.11"
+                    }
+                }
+            }
+        },
+        "@emotion/serialize": {
+            "version": "1.1.2",
+            "requires": {
+                "@emotion/hash": "^0.9.1",
+                "@emotion/memoize": "^0.8.1",
+                "@emotion/unitless": "^0.8.1",
+                "@emotion/utils": "^1.2.1",
+                "csstype": "^3.0.2"
+            }
+        },
+        "@emotion/sheet": {
+            "version": "1.2.2"
+        },
+        "@emotion/unitless": {
+            "version": "0.8.1"
+        },
+        "@emotion/use-insertion-effect-with-fallbacks": {
+            "version": "1.0.1",
+            "requires": {}
+        },
+        "@emotion/utils": {
+            "version": "1.2.1"
+        },
+        "@emotion/weak-memoize": {
+            "version": "0.3.1"
+        },
+        "@esbuild/android-arm": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.11.tgz",
+            "integrity": "sha512-q4qlUf5ucwbUJZXF5tEQ8LF7y0Nk4P58hOsGk3ucY0oCwgQqAnqXVbUuahCddVHfrxmpyewRpiTHwVHIETYu7Q==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-arm64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.11.tgz",
+            "integrity": "sha512-snieiq75Z1z5LJX9cduSAjUr7vEI1OdlzFPMw0HH5YI7qQHDd3qs+WZoMrWYDsfRJSq36lIA6mfZBkvL46KoIw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-x64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.11.tgz",
+            "integrity": "sha512-iPuoxQEV34+hTF6FT7om+Qwziv1U519lEOvekXO9zaMMlT9+XneAhKL32DW3H7okrCOBQ44BMihE8dclbZtTuw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/darwin-arm64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.11.tgz",
+            "integrity": "sha512-Gm0QkI3k402OpfMKyQEEMG0RuW2LQsSmI6OeO4El2ojJMoF5NLYb3qMIjvbG/lbMeLOGiW6ooU8xqc+S0fgz2w==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/darwin-x64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.11.tgz",
+            "integrity": "sha512-N15Vzy0YNHu6cfyDOjiyfJlRJCB/ngKOAvoBf1qybG3eOq0SL2Lutzz9N7DYUbb7Q23XtHPn6lMDF6uWbGv9Fw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/freebsd-arm64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.11.tgz",
+            "integrity": "sha512-atEyuq6a3omEY5qAh5jIORWk8MzFnCpSTUruBgeyN9jZq1K/QI9uke0ATi3MHu4L8c59CnIi4+1jDKMuqmR71A==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/freebsd-x64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.11.tgz",
+            "integrity": "sha512-XtuPrEfBj/YYYnAAB7KcorzzpGTvOr/dTtXPGesRfmflqhA4LMF0Gh/n5+a9JBzPuJ+CGk17CA++Hmr1F/gI0Q==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-arm": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.11.tgz",
+            "integrity": "sha512-Idipz+Taso/toi2ETugShXjQ3S59b6m62KmLHkJlSq/cBejixmIydqrtM2XTvNCywFl3VC7SreSf6NV0i6sRyg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-arm64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.11.tgz",
+            "integrity": "sha512-c6Vh2WS9VFKxKZ2TvJdA7gdy0n6eSy+yunBvv4aqNCEhSWVor1TU43wNRp2YLO9Vng2G+W94aRz+ILDSwAiYog==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-ia32": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.11.tgz",
+            "integrity": "sha512-S3hkIF6KUqRh9n1Q0dSyYcWmcVa9Cg+mSoZEfFuzoYXXsk6196qndrM+ZiHNwpZKi3XOXpShZZ+9dfN5ykqjjw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-loong64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.11.tgz",
+            "integrity": "sha512-MRESANOoObQINBA+RMZW+Z0TJWpibtE7cPFnahzyQHDCA9X9LOmGh68MVimZlM9J8n5Ia8lU773te6O3ILW8kw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-mips64el": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.11.tgz",
+            "integrity": "sha512-qVyPIZrXNMOLYegtD1u8EBccCrBVshxMrn5MkuFc3mEVsw7CCQHaqZ4jm9hbn4gWY95XFnb7i4SsT3eflxZsUg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-ppc64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.11.tgz",
+            "integrity": "sha512-T3yd8vJXfPirZaUOoA9D2ZjxZX4Gr3QuC3GztBJA6PklLotc/7sXTOuuRkhE9W/5JvJP/K9b99ayPNAD+R+4qQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-riscv64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.11.tgz",
+            "integrity": "sha512-evUoRPWiwuFk++snjH9e2cAjF5VVSTj+Dnf+rkO/Q20tRqv+644279TZlPK8nUGunjPAtQRCj1jQkDAvL6rm2w==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-s390x": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.11.tgz",
+            "integrity": "sha512-/SlRJ15XR6i93gRWquRxYCfhTeC5PdqEapKoLbX63PLCmAkXZHY2uQm2l9bN0oPHBsOw2IswRZctMYS0MijFcg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-x64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.11.tgz",
+            "integrity": "sha512-xcncej+wF16WEmIwPtCHi0qmx1FweBqgsRtEL1mSHLFR6/mb3GEZfLQnx+pUDfRDEM4DQF8dpXIW7eDOZl1IbA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/netbsd-x64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.11.tgz",
+            "integrity": "sha512-aSjMHj/F7BuS1CptSXNg6S3M4F3bLp5wfFPIJM+Km2NfIVfFKhdmfHF9frhiCLIGVzDziggqWll0B+9AUbud/Q==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/openbsd-x64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.11.tgz",
+            "integrity": "sha512-tNBq+6XIBZtht0xJGv7IBB5XaSyvYPCm1PxJ33zLQONdZoLVM0bgGqUrXnJyiEguD9LU4AHiu+GCXy/Hm9LsdQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/sunos-x64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.11.tgz",
+            "integrity": "sha512-kxfbDOrH4dHuAAOhr7D7EqaYf+W45LsAOOhAet99EyuxxQmjbk8M9N4ezHcEiCYPaiW8Dj3K26Z2V17Gt6p3ng==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-arm64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.11.tgz",
+            "integrity": "sha512-Sh0dDRyk1Xi348idbal7lZyfSkjhJsdFeuC13zqdipsvMetlGiFQNdO+Yfp6f6B4FbyQm7qsk16yaZk25LChzg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-ia32": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.11.tgz",
+            "integrity": "sha512-o9JUIKF1j0rqJTFbIoF4bXj6rvrTZYOrfRcGyL0Vm5uJ/j5CkBD/51tpdxe9lXEDouhRgdr/BYzUrDOvrWwJpg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-x64": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.11.tgz",
+            "integrity": "sha512-rQI4cjLHd2hGsM1LqgDI7oOCYbQ6IBOVsX9ejuRMSze0GqXUG2ekwiKkiBU1pRGSeCqFFHxTrcEydB2Hyoz9CA==",
+            "dev": true,
+            "optional": true
+        },
+        "@floating-ui/core": {
+            "version": "1.2.6"
+        },
+        "@floating-ui/dom": {
+            "version": "1.2.9",
+            "requires": {
+                "@floating-ui/core": "^1.2.6"
+            }
+        },
+        "@fortawesome/fontawesome-common-types": {
+            "version": "6.4.0"
+        },
+        "@fortawesome/fontawesome-svg-core": {
+            "version": "6.4.0",
+            "requires": {
+                "@fortawesome/fontawesome-common-types": "6.4.0"
+            }
+        },
+        "@fortawesome/free-solid-svg-icons": {
+            "version": "6.4.0",
+            "requires": {
+                "@fortawesome/fontawesome-common-types": "6.4.0"
+            }
+        },
+        "@fortawesome/react-fontawesome": {
+            "version": "0.2.0",
+            "requires": {
+                "prop-types": "^15.8.1"
+            }
+        },
+        "@ginkgo-bioworks/react-json-schema-form-builder": {
+            "version": "2.10.2",
+            "requires": {
+                "@fortawesome/fontawesome-svg-core": "^6.1.1",
+                "@fortawesome/free-solid-svg-icons": "^5.15.3 || ^6.1.1",
+                "@fortawesome/react-fontawesome": "^0.1.14 || ^0.2.0",
+                "classnames": "^2.2.6",
+                "react-beautiful-dnd": "^13.0.0",
+                "react-jss": "^10.4.0",
+                "react-select": "^5.0.0",
+                "reactstrap": "^8.10.0 || ^9.0.0"
+            }
+        },
+        "@jridgewell/gen-mapping": {
+            "version": "0.3.3",
+            "requires": {
+                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            },
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": {
+                    "version": "1.4.15"
+                }
+            }
+        },
+        "@jridgewell/resolve-uri": {
+            "version": "3.1.0"
+        },
+        "@jridgewell/set-array": {
+            "version": "1.1.2"
+        },
+        "@jridgewell/source-map": {
+            "version": "0.3.2",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@jridgewell/gen-mapping": "^0.3.0",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            }
+        },
+        "@jridgewell/sourcemap-codec": {
+            "version": "1.4.14"
+        },
+        "@jridgewell/trace-mapping": {
+            "version": "0.3.18",
+            "requires": {
+                "@jridgewell/resolve-uri": "3.1.0",
+                "@jridgewell/sourcemap-codec": "1.4.14"
+            }
+        },
+        "@monaco-editor/loader": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+            "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+            "requires": {
+                "state-local": "^1.0.6"
+            }
+        },
+        "@monaco-editor/react": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+            "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+            "requires": {
+                "@monaco-editor/loader": "^1.4.0"
+            }
+        },
+        "@novnc/novnc": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.4.0.tgz",
+            "integrity": "sha512-kW6ALMc5BuH08e/ond/I1naYcfjc19JYMN1EdtmgjjjzPGCjW8fMtVM3MwM6q7YLRjPlQ3orEvoKMgSS7RkEVQ=="
+        },
+        "@popperjs/core": {
+            "version": "2.11.8"
+        },
+        "@remix-run/router": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz",
+            "integrity": "sha512-Lm+fYpMfZoEucJ7cMxgt4dYt8jLfbpwRCzAjm9UgSLOkmlqo9gupxt6YX3DY0Fk155NT9l17d/ydi+964uS9Lw=="
+        },
+        "@rjsf/core": {
+            "version": "4.2.3",
+            "requires": {
+                "@types/json-schema": "^7.0.7",
+                "ajv": "^6.7.0",
+                "core-js-pure": "^3.6.5",
+                "json-schema-merge-allof": "^0.6.0",
+                "jsonpointer": "^5.0.0",
+                "lodash": "^4.17.15",
+                "lodash-es": "^4.17.15",
+                "nanoid": "^3.1.23",
+                "prop-types": "^15.7.2",
+                "react-is": "16.9.0"
+            }
+        },
+        "@rollup/pluginutils": {
+            "version": "4.2.1",
+            "dev": true,
+            "requires": {
+                "estree-walker": "^2.0.1",
+                "picomatch": "^2.2.2"
+            }
+        },
+        "@styled-system/background": {
+            "version": "5.1.2",
+            "requires": {
+                "@styled-system/core": "^5.1.2"
+            }
+        },
+        "@styled-system/border": {
+            "version": "5.1.5",
+            "requires": {
+                "@styled-system/core": "^5.1.2"
+            }
+        },
+        "@styled-system/color": {
+            "version": "5.1.2",
+            "requires": {
+                "@styled-system/core": "^5.1.2"
+            }
+        },
+        "@styled-system/core": {
+            "version": "5.1.2",
+            "requires": {
+                "object-assign": "^4.1.1"
+            }
+        },
+        "@styled-system/css": {
+            "version": "5.1.5"
+        },
+        "@styled-system/flexbox": {
+            "version": "5.1.2",
+            "requires": {
+                "@styled-system/core": "^5.1.2"
+            }
+        },
+        "@styled-system/grid": {
+            "version": "5.1.2",
+            "requires": {
+                "@styled-system/core": "^5.1.2"
+            }
+        },
+        "@styled-system/layout": {
+            "version": "5.1.2",
+            "requires": {
+                "@styled-system/core": "^5.1.2"
+            }
+        },
+        "@styled-system/position": {
+            "version": "5.1.2",
+            "requires": {
+                "@styled-system/core": "^5.1.2"
+            }
+        },
+        "@styled-system/shadow": {
+            "version": "5.1.2",
+            "requires": {
+                "@styled-system/core": "^5.1.2"
+            }
+        },
+        "@styled-system/space": {
+            "version": "5.1.2",
+            "requires": {
+                "@styled-system/core": "^5.1.2"
+            }
+        },
+        "@styled-system/typography": {
+            "version": "5.1.2",
+            "requires": {
+                "@styled-system/core": "^5.1.2"
+            }
+        },
+        "@styled-system/variant": {
+            "version": "5.1.5",
+            "requires": {
+                "@styled-system/core": "^5.1.2",
+                "@styled-system/css": "^5.1.5"
+            }
+        },
+        "@svgr/babel-plugin-add-jsx-attribute": {
+            "version": "5.4.0"
+        },
+        "@svgr/babel-plugin-remove-jsx-attribute": {
+            "version": "5.4.0"
+        },
+        "@svgr/babel-plugin-remove-jsx-empty-expression": {
+            "version": "5.0.1"
+        },
+        "@svgr/babel-plugin-replace-jsx-attribute-value": {
+            "version": "5.0.1"
+        },
+        "@svgr/babel-plugin-svg-dynamic-title": {
+            "version": "5.4.0"
+        },
+        "@svgr/babel-plugin-svg-em-dimensions": {
+            "version": "5.4.0"
+        },
+        "@svgr/babel-plugin-transform-react-native-svg": {
+            "version": "5.4.0"
+        },
+        "@svgr/babel-plugin-transform-svg-component": {
+            "version": "5.5.0"
+        },
+        "@svgr/babel-preset": {
+            "version": "5.5.0",
+            "requires": {
+                "@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
+                "@svgr/babel-plugin-remove-jsx-attribute": "^5.4.0",
+                "@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
+                "@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
+                "@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
+                "@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
+                "@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
+                "@svgr/babel-plugin-transform-svg-component": "^5.5.0"
+            }
+        },
+        "@svgr/cli": {
+            "version": "5.5.0",
+            "requires": {
+                "@svgr/core": "^5.5.0",
+                "@svgr/plugin-jsx": "^5.5.0",
+                "@svgr/plugin-prettier": "^5.5.0",
+                "@svgr/plugin-svgo": "^5.5.0",
+                "camelcase": "^6.2.0",
+                "chalk": "^4.1.0",
+                "commander": "^6.2.0",
+                "dashify": "^2.0.0",
+                "glob": "^7.1.4"
+            }
+        },
+        "@svgr/core": {
+            "version": "5.5.0",
+            "requires": {
+                "@svgr/plugin-jsx": "^5.5.0",
+                "camelcase": "^6.2.0",
+                "cosmiconfig": "^7.0.0"
+            }
+        },
+        "@svgr/hast-util-to-babel-ast": {
+            "version": "5.5.0",
+            "requires": {
+                "@babel/types": "^7.12.6"
+            }
+        },
+        "@svgr/plugin-jsx": {
+            "version": "5.5.0",
+            "requires": {
+                "@babel/core": "^7.12.3",
+                "@svgr/babel-preset": "^5.5.0",
+                "@svgr/hast-util-to-babel-ast": "^5.5.0",
+                "svg-parser": "^2.0.2"
+            }
+        },
+        "@svgr/plugin-prettier": {
+            "version": "5.5.0",
+            "requires": {
+                "deepmerge": "^4.2.2",
+                "prettier": "^2.1.2"
+            }
+        },
+        "@svgr/plugin-svgo": {
+            "version": "5.5.0",
+            "requires": {
+                "cosmiconfig": "^7.0.0",
+                "deepmerge": "^4.2.2",
+                "svgo": "^1.2.2"
+            }
+        },
+        "@types/debug": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.9.tgz",
+            "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
+            "requires": {
+                "@types/ms": "*"
+            }
+        },
+        "@types/eslint": {
+            "version": "8.4.10",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "@types/eslint-scope": {
+            "version": "3.7.4",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
+            }
+        },
+        "@types/estree": {
+            "version": "0.0.51",
+            "dev": true,
+            "peer": true
+        },
+        "@types/hast": {
+            "version": "2.3.4",
+            "requires": {
+                "@types/unist": "*"
+            }
+        },
+        "@types/history": {
+            "version": "5.0.0",
+            "dev": true,
+            "requires": {
+                "history": "*"
+            }
+        },
+        "@types/hoist-non-react-statics": {
+            "version": "3.3.1",
+            "requires": {
+                "@types/react": "*",
+                "hoist-non-react-statics": "^3.3.0"
+            }
+        },
+        "@types/json-schema": {
+            "version": "7.0.14",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
+            "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw=="
+        },
+        "@types/jsrsasign": {
+            "version": "10.5.11",
+            "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.11.tgz",
+            "integrity": "sha512-dBjGoI99kzjDe79LEfOpSHjc/U2BnEvY/FG6Yy1qvPYS2S0yxuWRKOk2Urzh3vGeb5dDq2JRqzilSKhH05t//Q==",
+            "dev": true
+        },
+        "@types/mdast": {
+            "version": "3.0.13",
+            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.13.tgz",
+            "integrity": "sha512-HjiGiWedR0DVFkeNljpa6Lv4/IZU1+30VY5d747K7lBudFc3R0Ibr6yJ9lN3BE28VnZyDfLF/VB1Ql1ZIbKrmg==",
+            "requires": {
+                "@types/unist": "^2"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.8",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+                    "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+                }
+            }
+        },
+        "@types/ms": {
+            "version": "0.7.32",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.32.tgz",
+            "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g=="
+        },
+        "@types/node": {
+            "version": "18.7.18",
+            "dev": true,
+            "peer": true
+        },
+        "@types/parse-json": {
+            "version": "4.0.0"
+        },
+        "@types/prop-types": {
+            "version": "15.7.5"
+        },
+        "@types/q": {
+            "version": "1.5.5"
+        },
+        "@types/react": {
+            "version": "18.2.29",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.29.tgz",
+            "integrity": "sha512-Z+ZrIRocWtdD70j45izShRwDuiB4JZqDegqMFW/I8aG5DxxLKOzVNoq62UIO82v9bdgi+DO1jvsb9sTEZUSm+Q==",
+            "requires": {
+                "@types/prop-types": "*",
+                "@types/scheduler": "*",
+                "csstype": "^3.0.2"
+            }
+        },
+        "@types/react-datepicker": {
+            "version": "4.15.1",
+            "resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-4.15.1.tgz",
+            "integrity": "sha512-6/LthK0pTDBKjjVJqA2ygY3jJsHH7uZXIk8WPQcGHUiFOQLOKIv3krOxFZ2mt3BB3guMB6jVTc6ansQAd0r7xQ==",
+            "dev": true,
+            "requires": {
+                "@popperjs/core": "^2.9.2",
+                "@types/react": "*",
+                "date-fns": "^2.0.1",
+                "react-popper": "^2.2.5"
+            }
+        },
+        "@types/react-dom": {
+            "version": "18.2.14",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.14.tgz",
+            "integrity": "sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==",
+            "devOptional": true,
+            "requires": {
+                "@types/react": "*"
+            }
+        },
+        "@types/react-dropzone": {
+            "version": "5.1.0",
+            "dev": true,
+            "requires": {
+                "react-dropzone": "*"
+            }
+        },
+        "@types/react-modal": {
+            "version": "3.16.2",
+            "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.2.tgz",
+            "integrity": "sha512-4LIHFLP8EmQnps3QhUIPyfF87b1BGikQD/MHuYNdx/30gH1d4Q3OUtyqrh6GUfifNVMPWXOrlRekJDWzPzu1Gg==",
+            "dev": true,
+            "requires": {
+                "@types/react": "*"
+            }
+        },
+        "@types/react-redux": {
+            "version": "7.1.28",
+            "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.28.tgz",
+            "integrity": "sha512-EQr7cChVzVUuqbA+J8ArWK1H0hLAHKOs21SIMrskKZ3nHNeE+LFYA+IsoZGhVOT8Ktjn3M20v4rnZKN3fLbypw==",
+            "requires": {
+                "@types/hoist-non-react-statics": "^3.3.0",
+                "@types/react": "*",
+                "hoist-non-react-statics": "^3.3.0",
+                "redux": "^4.0.0"
+            }
+        },
+        "@types/react-transition-group": {
+            "version": "4.4.8",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.8.tgz",
+            "integrity": "sha512-QmQ22q+Pb+HQSn04NL3HtrqHwYMf4h3QKArOy5F8U5nEVMaihBs3SR10WiOM1iwPz5jIo8x/u11al+iEGZZrvg==",
+            "requires": {
+                "@types/react": "*"
+            }
+        },
+        "@types/react-virtualized-auto-sizer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz",
+            "integrity": "sha512-UKIhAsnn1GknB0ewLXmwiGPVhU9m58gq56HcS1+G9L+TUtwgLMJoCREH0k303t3ZdDhNWt8TyxWE9iLYzWSnew==",
+            "dev": true,
+            "requires": {
+                "@types/react": "*"
+            }
+        },
+        "@types/react-window": {
+            "version": "1.8.7",
+            "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.7.tgz",
+            "integrity": "sha512-FpPHEhmGVOBKomuR4LD2nvua1Ajcw6PfnfbDysuCwwPae3JNulcq3+uZIpQNbDN2AI1z+Y4tKj2xQ4ELiQ4QDw==",
+            "dev": true,
+            "requires": {
+                "@types/react": "*"
+            }
+        },
+        "@types/scheduler": {
+            "version": "0.16.3"
+        },
+        "@types/styled-system": {
+            "version": "5.1.20",
+            "resolved": "https://registry.npmjs.org/@types/styled-system/-/styled-system-5.1.20.tgz",
+            "integrity": "sha512-oiaziko13jwrjmOCYfosXds7ZoPtWyBU96ONYtmYL2c+yh/yjcqVDs+w78VpTHLwZZ01yU9//ZyIhxqay8vbCw==",
+            "dev": true,
+            "requires": {
+                "csstype": "^3.0.2"
+            }
+        },
+        "@types/stylis": {
+            "version": "4.2.0"
+        },
+        "@types/ua-parser-js": {
+            "version": "0.7.38",
+            "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.38.tgz",
+            "integrity": "sha512-59CA5oavBEWSNLtS/BChj9xntiWMsIf9IytjxmBo9OuZEYuRzRf3K1ARzFPlXTOz5Zm2wXI38AP9RlLqDYMToQ==",
+            "dev": true
+        },
+        "@types/unist": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+            "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
+        },
+        "@types/use-sync-external-store": {
+            "version": "0.0.3"
+        },
+        "@vitejs/plugin-react-refresh": {
+            "version": "1.3.6",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.14.8",
+                "@babel/plugin-transform-react-jsx-self": "^7.14.5",
+                "@babel/plugin-transform-react-jsx-source": "^7.14.5",
+                "@rollup/pluginutils": "^4.1.1",
+                "react-refresh": "^0.10.0"
+            }
+        },
+        "@webassemblyjs/ast": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/helper-numbers": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+            }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true
+        },
+        "@webassemblyjs/helper-api-error": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true
+        },
+        "@webassemblyjs/helper-buffer": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true
+        },
+        "@webassemblyjs/helper-numbers": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1"
+            }
+        },
+        "@webassemblyjs/ieee754": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "@webassemblyjs/leb128": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/utf8": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true
+        },
+        "@webassemblyjs/wasm-edit": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/helper-wasm-section": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-opt": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "@webassemblyjs/wast-printer": "1.11.1"
+            }
+        },
+        "@webassemblyjs/wasm-gen": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
+            }
+        },
+        "@webassemblyjs/wasm-opt": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1"
+            }
+        },
+        "@webassemblyjs/wasm-parser": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
+            }
+        },
+        "@webassemblyjs/wast-printer": {
+            "version": "1.11.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@xtuc/ieee754": {
+            "version": "1.2.0",
+            "dev": true,
+            "peer": true
+        },
+        "@xtuc/long": {
+            "version": "4.2.2",
+            "dev": true,
+            "peer": true
+        },
+        "@yr/monotone-cubic-spline": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
+            "integrity": "sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA=="
+        },
+        "acorn": {
+            "version": "8.8.0",
+            "dev": true,
+            "peer": true
+        },
+        "acorn-import-assertions": {
+            "version": "1.8.0",
+            "dev": true,
+            "peer": true,
+            "requires": {}
+        },
+        "ajv": {
+            "version": "6.12.6",
+            "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ajv-keywords": {
+            "version": "3.5.2",
+            "dev": true,
+            "peer": true,
+            "requires": {}
+        },
+        "ansi-styles": {
+            "version": "4.3.0",
+            "requires": {
+                "color-convert": "^2.0.1"
+            }
+        },
+        "apexcharts": {
+            "version": "3.44.0",
+            "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.44.0.tgz",
+            "integrity": "sha512-u7Xzrbcxc2yWznN78Jh5NMCYVAsWDfBjRl5ea++rVzFAqjU2hLz4RgKIFwYOBDRQtW1e/Qz8azJTqIJ1+Vu9Qg==",
+            "requires": {
+                "@yr/monotone-cubic-spline": "^1.0.3",
+                "svg.draggable.js": "^2.2.2",
+                "svg.easing.js": "^2.0.0",
+                "svg.filter.js": "^2.0.2",
+                "svg.pathmorphing.js": "^0.1.3",
+                "svg.resize.js": "^1.4.3",
+                "svg.select.js": "^3.0.1"
+            }
+        },
+        "argparse": {
+            "version": "2.0.1"
+        },
+        "array-buffer-byte-length": {
+            "version": "1.0.0",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "is-array-buffer": "^3.0.1"
+            }
+        },
+        "array.prototype.reduce": {
+            "version": "1.0.5",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4",
+                "es-array-method-boxes-properly": "^1.0.0",
+                "is-string": "^1.0.7"
+            }
+        },
+        "ascii-tree": {
+            "version": "0.3.0",
+            "requires": {
+                "freetree": "0.2.2"
+            }
+        },
+        "assert": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+            "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "is-nan": "^1.3.2",
+                "object-is": "^1.1.5",
+                "object.assign": "^4.1.4",
+                "util": "^0.12.5"
+            }
+        },
+        "attr-accept": {
+            "version": "2.2.2",
+            "dev": true
+        },
+        "available-typed-arrays": {
+            "version": "1.0.5"
+        },
+        "babel-plugin-macros": {
+            "version": "3.1.0",
+            "requires": {
+                "@babel/runtime": "^7.12.5",
+                "cosmiconfig": "^7.0.0",
+                "resolve": "^1.19.0"
+            }
+        },
+        "bail": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+            "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+        },
+        "balanced-match": {
+            "version": "1.0.2"
+        },
+        "boolbase": {
+            "version": "1.0.0"
+        },
+        "bootstrap": {
+            "version": "5.2.2",
+            "peer": true,
+            "requires": {}
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "3.0.2",
+            "dev": true,
+            "requires": {
+                "fill-range": "^7.0.1"
+            }
+        },
+        "browserslist": {
+            "version": "4.21.5",
+            "requires": {
+                "caniuse-lite": "^1.0.30001449",
+                "electron-to-chromium": "^1.4.284",
+                "node-releases": "^2.0.8",
+                "update-browserslist-db": "^1.0.10"
+            }
+        },
+        "buffer-from": {
+            "version": "1.1.2",
+            "dev": true,
+            "peer": true
+        },
+        "call-bind": {
+            "version": "1.0.2",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            }
+        },
+        "callsites": {
+            "version": "3.1.0"
+        },
+        "camelcase": {
+            "version": "6.3.0"
+        },
+        "camelize": {
+            "version": "1.0.1"
+        },
+        "caniuse-lite": {
+            "version": "1.0.30001478"
+        },
+        "chalk": {
+            "version": "4.1.2",
+            "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            }
+        },
+        "character-entities": {
+            "version": "1.2.4"
+        },
+        "character-entities-legacy": {
+            "version": "1.1.4"
+        },
+        "character-reference-invalid": {
+            "version": "1.1.4"
+        },
+        "chrome-trace-event": {
+            "version": "1.0.3",
+            "dev": true,
+            "peer": true
+        },
+        "classnames": {
+            "version": "2.3.2"
+        },
+        "cli-table": {
+            "version": "0.3.11",
+            "requires": {
+                "colors": "1.0.3"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "1.0.3"
+                }
+            }
+        },
+        "coa": {
+            "version": "2.0.2",
+            "requires": {
+                "@types/q": "^1.5.1",
+                "chalk": "^2.4.1",
+                "q": "^1.1.2"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    },
+                    "dependencies": {
+                        "ansi-styles": {
+                            "version": "3.2.1",
+                            "requires": {
+                                "color-convert": "^1.9.0"
+                            },
+                            "dependencies": {
+                                "color-convert": {
+                                    "version": "1.9.3",
+                                    "requires": {
+                                        "color-name": "1.1.3"
+                                    },
+                                    "dependencies": {
+                                        "color-name": {
+                                            "version": "1.1.3"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "color-convert": {
+            "version": "2.0.1",
+            "requires": {
+                "color-name": "~1.1.4"
+            }
+        },
+        "color-name": {
+            "version": "1.1.4"
+        },
+        "colors": {
+            "version": "1.4.0"
+        },
+        "comma-separated-tokens": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+            "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
+        },
+        "commander": {
+            "version": "6.2.1"
+        },
+        "compute-gcd": {
+            "version": "1.2.1",
+            "requires": {
+                "validate.io-array": "^1.0.3",
+                "validate.io-function": "^1.0.2",
+                "validate.io-integer-array": "^1.0.0"
+            }
+        },
+        "compute-lcm": {
+            "version": "1.1.2",
+            "requires": {
+                "compute-gcd": "^1.2.1",
+                "validate.io-array": "^1.0.3",
+                "validate.io-function": "^1.0.2",
+                "validate.io-integer-array": "^1.0.0"
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1"
+        },
+        "convert-source-map": {
+            "version": "1.9.0"
+        },
+        "core-js-pure": {
+            "version": "3.30.0"
+        },
+        "cosmiconfig": {
+            "version": "7.1.0",
+            "requires": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
+            }
+        },
+        "css-box-model": {
+            "version": "1.2.1",
+            "requires": {
+                "tiny-invariant": "^1.0.6"
+            }
+        },
+        "css-color-keywords": {
+            "version": "1.0.0"
+        },
+        "css-jss": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "^10.10.0",
+                "jss-preset-default": "^10.10.0"
+            }
+        },
+        "css-select": {
+            "version": "2.1.0",
+            "requires": {
+                "boolbase": "^1.0.0",
+                "css-what": "^3.2.1",
+                "domutils": "^1.7.0",
+                "nth-check": "^1.0.2"
+            }
+        },
+        "css-select-base-adapter": {
+            "version": "0.1.1"
+        },
+        "css-to-react-native": {
+            "version": "3.2.0",
+            "requires": {
+                "camelize": "^1.0.0",
+                "css-color-keywords": "^1.0.0",
+                "postcss-value-parser": "^4.0.2"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0"
+                }
+            }
+        },
+        "css-tree": {
+            "version": "1.0.0-alpha.37",
+            "requires": {
+                "mdn-data": "2.0.4",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1"
+                }
+            }
+        },
+        "css-unit-converter": {
+            "version": "1.1.2"
+        },
+        "css-vendor": {
+            "version": "2.0.8",
+            "requires": {
+                "@babel/runtime": "^7.8.3",
+                "is-in-browser": "^1.0.2"
+            }
+        },
+        "css-what": {
+            "version": "3.4.2"
+        },
+        "csso": {
+            "version": "4.2.0",
+            "requires": {
+                "css-tree": "^1.1.2"
+            },
+            "dependencies": {
+                "css-tree": {
+                    "version": "1.1.3",
+                    "requires": {
+                        "mdn-data": "2.0.14",
+                        "source-map": "^0.6.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1"
+                        }
+                    }
+                },
+                "mdn-data": {
+                    "version": "2.0.14",
+                    "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+                    "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+                }
+            }
+        },
+        "csstype": {
+            "version": "3.1.2"
+        },
+        "d3-array": {
+            "version": "3.2.3",
+            "requires": {
+                "internmap": "1 - 2"
+            }
+        },
+        "d3-color": {
+            "version": "3.1.0"
+        },
+        "d3-format": {
+            "version": "3.1.0"
+        },
+        "d3-interpolate": {
+            "version": "3.0.1",
+            "requires": {
+                "d3-color": "1 - 3"
+            }
+        },
+        "d3-path": {
+            "version": "3.1.0"
+        },
+        "d3-scale": {
+            "version": "4.0.2",
+            "requires": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            }
+        },
+        "d3-shape": {
+            "version": "3.2.0",
+            "requires": {
+                "d3-path": "^3.1.0"
+            }
+        },
+        "d3-time": {
+            "version": "3.1.0",
+            "requires": {
+                "d3-array": "2 - 3"
+            }
+        },
+        "d3-time-format": {
+            "version": "4.1.0",
+            "requires": {
+                "d3-time": "1 - 3"
+            }
+        },
+        "dashify": {
+            "version": "2.0.0"
+        },
+        "date-fns": {
+            "version": "2.30.0",
+            "requires": {
+                "@babel/runtime": "^7.21.0"
+            }
+        },
+        "debug": {
+            "version": "4.3.4",
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
+        "decimal.js-light": {
+            "version": "2.5.1"
+        },
+        "decode-named-character-reference": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+            "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+            "requires": {
+                "character-entities": "^2.0.0"
+            },
+            "dependencies": {
+                "character-entities": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+                    "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
+                }
+            }
+        },
+        "deepcopy": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/deepcopy/-/deepcopy-2.1.0.tgz",
+            "integrity": "sha512-8cZeTb1ZKC3bdSCP6XOM1IsTczIO73fdqtwa2B0N15eAz7gmyhQo+mc5gnFuulsgN3vIQYmTgbmQVKalH1dKvQ==",
+            "requires": {
+                "type-detect": "^4.0.8"
+            }
+        },
+        "deepmerge": {
+            "version": "4.3.1"
+        },
+        "define-properties": {
+            "version": "1.2.0",
+            "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            }
+        },
+        "dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
+        },
+        "diff": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
+        },
+        "dom-helpers": {
+            "version": "5.2.1",
+            "requires": {
+                "@babel/runtime": "^7.8.7",
+                "csstype": "^3.0.2"
+            }
+        },
+        "dom-serializer": {
+            "version": "0.2.2",
+            "requires": {
+                "domelementtype": "^2.0.1",
+                "entities": "^2.0.0"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "2.3.0"
+                }
+            }
+        },
+        "domelementtype": {
+            "version": "1.3.1"
+        },
+        "domutils": {
+            "version": "1.7.0",
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
+        "electron-to-chromium": {
+            "version": "1.4.359"
+        },
+        "enhanced-resolve": {
+            "version": "5.15.0",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            }
+        },
+        "entities": {
+            "version": "2.2.0"
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.21.2",
+            "requires": {
+                "array-buffer-byte-length": "^1.0.0",
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "es-set-tostringtag": "^2.0.1",
+                "es-to-primitive": "^1.2.1",
+                "function.prototype.name": "^1.1.5",
+                "get-intrinsic": "^1.2.0",
+                "get-symbol-description": "^1.0.0",
+                "globalthis": "^1.0.3",
+                "gopd": "^1.0.1",
+                "has": "^1.0.3",
+                "has-property-descriptors": "^1.0.0",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "internal-slot": "^1.0.5",
+                "is-array-buffer": "^3.0.2",
+                "is-callable": "^1.2.7",
+                "is-negative-zero": "^2.0.2",
+                "is-regex": "^1.1.4",
+                "is-shared-array-buffer": "^1.0.2",
+                "is-string": "^1.0.7",
+                "is-typed-array": "^1.1.10",
+                "is-weakref": "^1.0.2",
+                "object-inspect": "^1.12.3",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.4",
+                "regexp.prototype.flags": "^1.4.3",
+                "safe-regex-test": "^1.0.0",
+                "string.prototype.trim": "^1.2.7",
+                "string.prototype.trimend": "^1.0.6",
+                "string.prototype.trimstart": "^1.0.6",
+                "typed-array-length": "^1.0.4",
+                "unbox-primitive": "^1.0.2",
+                "which-typed-array": "^1.1.9"
+            }
+        },
+        "es-array-method-boxes-properly": {
+            "version": "1.0.0"
+        },
+        "es-module-lexer": {
+            "version": "0.9.3",
+            "dev": true,
+            "peer": true
+        },
+        "es-set-tostringtag": {
+            "version": "2.0.1",
+            "requires": {
+                "get-intrinsic": "^1.1.3",
+                "has": "^1.0.3",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "esbuild": {
+            "version": "0.18.11",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.11.tgz",
+            "integrity": "sha512-i8u6mQF0JKJUlGR3OdFLKldJQMMs8OqM9Cc3UCi9XXziJ9WERM5bfkHaEAy0YAvPRMgqSW55W7xYn84XtEFTtA==",
+            "dev": true,
+            "requires": {
+                "@esbuild/android-arm": "0.18.11",
+                "@esbuild/android-arm64": "0.18.11",
+                "@esbuild/android-x64": "0.18.11",
+                "@esbuild/darwin-arm64": "0.18.11",
+                "@esbuild/darwin-x64": "0.18.11",
+                "@esbuild/freebsd-arm64": "0.18.11",
+                "@esbuild/freebsd-x64": "0.18.11",
+                "@esbuild/linux-arm": "0.18.11",
+                "@esbuild/linux-arm64": "0.18.11",
+                "@esbuild/linux-ia32": "0.18.11",
+                "@esbuild/linux-loong64": "0.18.11",
+                "@esbuild/linux-mips64el": "0.18.11",
+                "@esbuild/linux-ppc64": "0.18.11",
+                "@esbuild/linux-riscv64": "0.18.11",
+                "@esbuild/linux-s390x": "0.18.11",
+                "@esbuild/linux-x64": "0.18.11",
+                "@esbuild/netbsd-x64": "0.18.11",
+                "@esbuild/openbsd-x64": "0.18.11",
+                "@esbuild/sunos-x64": "0.18.11",
+                "@esbuild/win32-arm64": "0.18.11",
+                "@esbuild/win32-ia32": "0.18.11",
+                "@esbuild/win32-x64": "0.18.11"
+            }
+        },
+        "escalade": {
+            "version": "3.1.1"
+        },
+        "escape-string-regexp": {
+            "version": "4.0.0"
+        },
+        "eslint-scope": {
+            "version": "5.1.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "4.3.0",
+                    "dev": true,
+                    "peer": true
+                }
+            }
+        },
+        "esprima": {
+            "version": "4.0.1"
+        },
+        "esrecurse": {
+            "version": "4.3.0",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "estraverse": "^5.2.0"
+            }
+        },
+        "estraverse": {
+            "version": "5.3.0",
+            "dev": true,
+            "peer": true
+        },
+        "estree-walker": {
+            "version": "2.0.2",
+            "dev": true
+        },
+        "eventemitter3": {
+            "version": "4.0.7"
+        },
+        "events": {
+            "version": "3.3.0",
+            "dev": true,
+            "peer": true
+        },
+        "exenv": {
+            "version": "1.2.2"
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "fast-deep-equal": {
+            "version": "3.1.3"
+        },
+        "fast-equals": {
+            "version": "4.0.3"
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.1.0"
+        },
+        "fault": {
+            "version": "1.0.4",
+            "requires": {
+                "format": "^0.2.0"
+            }
+        },
+        "file-selector": {
+            "version": "0.6.0",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "filesize": {
+            "version": "8.0.7"
+        },
+        "fill-range": {
+            "version": "7.0.1",
+            "dev": true,
+            "requires": {
+                "to-regex-range": "^5.0.1"
+            }
+        },
+        "find-root": {
+            "version": "1.1.0"
+        },
+        "for-each": {
+            "version": "0.3.3",
+            "requires": {
+                "is-callable": "^1.1.3"
+            }
+        },
+        "format": {
+            "version": "0.2.2"
+        },
+        "freetree": {
+            "version": "0.2.2"
+        },
+        "fs.realpath": {
+            "version": "1.0.0"
+        },
+        "fsevents": {
+            "version": "2.3.2",
+            "dev": true,
+            "optional": true
+        },
+        "function-bind": {
+            "version": "1.1.1"
+        },
+        "function.prototype.name": {
+            "version": "1.1.5",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.19.0",
+                "functions-have-names": "^1.2.2"
+            }
+        },
+        "functions-have-names": {
+            "version": "1.2.3"
+        },
+        "fuse.js": {
+            "version": "6.6.2"
+        },
+        "gensync": {
+            "version": "1.0.0-beta.2"
+        },
+        "get-intrinsic": {
+            "version": "1.2.0",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.3"
+            }
+        },
+        "get-symbol-description": {
+            "version": "1.0.0",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.1"
+            }
+        },
+        "glob": {
+            "version": "7.2.3",
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "glob-to-regexp": {
+            "version": "0.4.1",
+            "dev": true,
+            "peer": true
+        },
+        "globals": {
+            "version": "11.12.0"
+        },
+        "globalthis": {
+            "version": "1.0.3",
+            "requires": {
+                "define-properties": "^1.1.3"
+            }
+        },
+        "gopd": {
+            "version": "1.0.1",
+            "requires": {
+                "get-intrinsic": "^1.1.3"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.11",
+            "dev": true
+        },
+        "has": {
+            "version": "1.0.3",
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-bigints": {
+            "version": "1.0.2"
+        },
+        "has-flag": {
+            "version": "4.0.0"
+        },
+        "has-property-descriptors": {
+            "version": "1.0.0",
+            "requires": {
+                "get-intrinsic": "^1.1.1"
+            }
+        },
+        "has-proto": {
+            "version": "1.0.1"
+        },
+        "has-symbols": {
+            "version": "1.0.3"
+        },
+        "has-tostringtag": {
+            "version": "1.0.0",
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "hast-util-parse-selector": {
+            "version": "2.2.5"
+        },
+        "hast-util-whitespace": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
+            "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng=="
+        },
+        "hastscript": {
+            "version": "6.0.0",
+            "requires": {
+                "@types/hast": "^2.0.0",
+                "comma-separated-tokens": "^1.0.0",
+                "hast-util-parse-selector": "^2.0.0",
+                "property-information": "^5.0.0",
+                "space-separated-tokens": "^1.0.0"
+            },
+            "dependencies": {
+                "comma-separated-tokens": {
+                    "version": "1.0.8"
+                },
+                "property-information": {
+                    "version": "5.6.0",
+                    "requires": {
+                        "xtend": "^4.0.0"
+                    }
+                },
+                "space-separated-tokens": {
+                    "version": "1.1.5"
+                }
+            }
+        },
+        "highlight.js": {
+            "version": "10.7.3"
+        },
+        "history": {
+            "version": "5.3.0",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.7.6"
+            }
+        },
+        "hoist-non-react-statics": {
+            "version": "3.3.2",
+            "requires": {
+                "react-is": "^16.7.0"
+            },
+            "dependencies": {
+                "react-is": {
+                    "version": "16.13.1"
+                }
+            }
+        },
+        "hyphenate-style-name": {
+            "version": "1.0.4"
+        },
+        "immediate": {
+            "version": "3.0.6"
+        },
+        "import-fresh": {
+            "version": "3.3.0",
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4"
+        },
+        "inline-style-parser": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+            "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
+        },
+        "internal-slot": {
+            "version": "1.0.5",
+            "requires": {
+                "get-intrinsic": "^1.2.0",
+                "has": "^1.0.3",
+                "side-channel": "^1.0.4"
+            }
+        },
+        "internmap": {
+            "version": "2.0.3"
+        },
+        "is-alphabetical": {
+            "version": "1.0.4"
+        },
+        "is-alphanumerical": {
+            "version": "1.0.4",
+            "requires": {
+                "is-alphabetical": "^1.0.0",
+                "is-decimal": "^1.0.0"
+            }
+        },
+        "is-arguments": {
+            "version": "1.1.1",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-array-buffer": {
+            "version": "3.0.2",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.0",
+                "is-typed-array": "^1.1.10"
+            }
+        },
+        "is-arrayish": {
+            "version": "0.2.1"
+        },
+        "is-bigint": {
+            "version": "1.0.4",
+            "requires": {
+                "has-bigints": "^1.0.1"
+            }
+        },
+        "is-boolean-object": {
+            "version": "1.1.2",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-buffer": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        },
+        "is-callable": {
+            "version": "1.2.7"
+        },
+        "is-core-module": {
+            "version": "2.12.0",
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.5",
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-decimal": {
+            "version": "1.0.4"
+        },
+        "is-generator-function": {
+            "version": "1.0.10",
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-hexadecimal": {
+            "version": "1.0.4"
+        },
+        "is-in-browser": {
+            "version": "1.1.3"
+        },
+        "is-nan": {
+            "version": "1.3.2",
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "is-negative-zero": {
+            "version": "2.0.2"
+        },
+        "is-number": {
+            "version": "7.0.0",
+            "dev": true
+        },
+        "is-number-object": {
+            "version": "1.0.7",
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        },
+        "is-regex": {
+            "version": "1.1.4",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-shared-array-buffer": {
+            "version": "1.0.2",
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
+        },
+        "is-string": {
+            "version": "1.0.7",
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-symbol": {
+            "version": "1.0.4",
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "is-typed-array": {
+            "version": "1.1.10",
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-weakref": {
+            "version": "1.0.2",
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
+        },
+        "jest-worker": {
+            "version": "27.5.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@types/node": "*",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "8.1.1",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "js-tokens": {
+            "version": "4.0.0"
+        },
+        "js-yaml": {
+            "version": "4.1.0",
+            "requires": {
+                "argparse": "^2.0.1"
+            }
+        },
+        "jsesc": {
+            "version": "2.5.2"
+        },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1"
+        },
+        "json-schema-compare": {
+            "version": "0.2.2",
+            "requires": {
+                "lodash": "^4.17.4"
+            }
+        },
+        "json-schema-merge-allof": {
+            "version": "0.6.0",
+            "requires": {
+                "compute-lcm": "^1.1.0",
+                "json-schema-compare": "^0.2.2",
+                "lodash": "^4.17.4"
+            }
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1"
+        },
+        "json5": {
+            "version": "2.2.3"
+        },
+        "jsonpointer": {
+            "version": "5.0.1"
+        },
+        "jsrsasign": {
+            "version": "10.8.6",
+            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
+            "integrity": "sha512-bQmbVtsfbgaKBTWCKiDCPlUPbdlRIK/FzSwT3BzIgZl/cU6TqXu6pZJsCI/dJVrZ9Gir5GC4woqw9shH/v7MBw=="
+        },
+        "jss": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "csstype": "^3.0.2",
+                "is-in-browser": "^1.1.3",
+                "tiny-warning": "^1.0.2"
+            }
+        },
+        "jss-plugin-camel-case": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "hyphenate-style-name": "^1.0.3",
+                "jss": "10.10.0"
+            }
+        },
+        "jss-plugin-compose": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.10.0",
+                "tiny-warning": "^1.0.2"
+            }
+        },
+        "jss-plugin-default-unit": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.10.0"
+            }
+        },
+        "jss-plugin-expand": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.10.0"
+            }
+        },
+        "jss-plugin-extend": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.10.0",
+                "tiny-warning": "^1.0.2"
+            }
+        },
+        "jss-plugin-global": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.10.0"
+            }
+        },
+        "jss-plugin-nested": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.10.0",
+                "tiny-warning": "^1.0.2"
+            }
+        },
+        "jss-plugin-props-sort": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.10.0"
+            }
+        },
+        "jss-plugin-rule-value-function": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.10.0",
+                "tiny-warning": "^1.0.2"
+            }
+        },
+        "jss-plugin-rule-value-observable": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.10.0",
+                "symbol-observable": "^1.2.0"
+            }
+        },
+        "jss-plugin-template": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.10.0",
+                "tiny-warning": "^1.0.2"
+            }
+        },
+        "jss-plugin-vendor-prefixer": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "css-vendor": "^2.0.8",
+                "jss": "10.10.0"
+            }
+        },
+        "jss-preset-default": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.10.0",
+                "jss-plugin-camel-case": "10.10.0",
+                "jss-plugin-compose": "10.10.0",
+                "jss-plugin-default-unit": "10.10.0",
+                "jss-plugin-expand": "10.10.0",
+                "jss-plugin-extend": "10.10.0",
+                "jss-plugin-global": "10.10.0",
+                "jss-plugin-nested": "10.10.0",
+                "jss-plugin-props-sort": "10.10.0",
+                "jss-plugin-rule-value-function": "10.10.0",
+                "jss-plugin-rule-value-observable": "10.10.0",
+                "jss-plugin-template": "10.10.0",
+                "jss-plugin-vendor-prefixer": "10.10.0"
+            }
+        },
+        "kleur": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+            "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
+        },
+        "lie": {
+            "version": "3.1.1",
+            "requires": {
+                "immediate": "~3.0.5"
+            }
+        },
+        "lines-and-columns": {
+            "version": "1.2.4"
+        },
+        "loader-runner": {
+            "version": "4.3.0",
+            "dev": true,
+            "peer": true
+        },
+        "localforage": {
+            "version": "1.10.0",
+            "requires": {
+                "lie": "3.1.1"
+            }
+        },
+        "lodash": {
+            "version": "4.17.21"
+        },
+        "lodash-es": {
+            "version": "4.17.21"
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "lowlight": {
+            "version": "1.20.0",
+            "requires": {
+                "fault": "^1.0.0",
+                "highlight.js": "~10.7.0"
+            }
+        },
+        "lru-cache": {
+            "version": "6.0.0",
+            "dev": true,
+            "requires": {
+                "yallist": "^4.0.0"
+            }
+        },
+        "magic-bytes.js": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.5.0.tgz",
+            "integrity": "sha512-wJkXvutRbNWcc37tt5j1HyOK1nosspdh3dj6LUYYAvF6JYNqs53IfRvK9oEpcwiDA1NdoIi64yAMfdivPeVAyw=="
+        },
+        "mdast-util-definitions": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
+            "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "@types/unist": "^2.0.0",
+                "unist-util-visit": "^4.0.0"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.8",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+                    "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+                }
+            }
+        },
+        "mdast-util-from-markdown": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+            "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "@types/unist": "^2.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "mdast-util-to-string": "^3.1.0",
+                "micromark": "^3.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-decode-string": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "unist-util-stringify-position": "^3.0.0",
+                "uvu": "^0.5.0"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.8",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+                    "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+                }
+            }
+        },
+        "mdast-util-to-hast": {
+            "version": "12.3.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
+            "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+            "requires": {
+                "@types/hast": "^2.0.0",
+                "@types/mdast": "^3.0.0",
+                "mdast-util-definitions": "^5.0.0",
+                "micromark-util-sanitize-uri": "^1.1.0",
+                "trim-lines": "^3.0.0",
+                "unist-util-generated": "^2.0.0",
+                "unist-util-position": "^4.0.0",
+                "unist-util-visit": "^4.0.0"
+            }
+        },
+        "mdast-util-to-string": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+            "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+            "requires": {
+                "@types/mdast": "^3.0.0"
+            }
+        },
+        "mdn-data": {
+            "version": "2.0.4"
+        },
+        "memoize-one": {
+            "version": "5.2.1"
+        },
+        "merge-stream": {
+            "version": "2.0.0",
+            "dev": true,
+            "peer": true
+        },
+        "micromark": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+            "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+            "requires": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-core-commonmark": "^1.0.1",
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-combine-extensions": "^1.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-encode": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-resolve-all": "^1.0.0",
+                "micromark-util-sanitize-uri": "^1.0.0",
+                "micromark-util-subtokenize": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.1",
+                "uvu": "^0.5.0"
+            }
+        },
+        "micromark-core-commonmark": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+            "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+            "requires": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-factory-destination": "^1.0.0",
+                "micromark-factory-label": "^1.0.0",
+                "micromark-factory-space": "^1.0.0",
+                "micromark-factory-title": "^1.0.0",
+                "micromark-factory-whitespace": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-classify-character": "^1.0.0",
+                "micromark-util-html-tag-name": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-resolve-all": "^1.0.0",
+                "micromark-util-subtokenize": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.1",
+                "uvu": "^0.5.0"
+            }
+        },
+        "micromark-factory-destination": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+            "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-factory-label": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+            "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "uvu": "^0.5.0"
+            }
+        },
+        "micromark-factory-space": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+            "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-factory-title": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+            "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+            "requires": {
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-factory-whitespace": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+            "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+            "requires": {
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-character": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+            "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+            "requires": {
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-chunked": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+            "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+            "requires": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-classify-character": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+            "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-combine-extensions": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+            "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+            "requires": {
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-decode-numeric-character-reference": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+            "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+            "requires": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-decode-string": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+            "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+            "requires": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-encode": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+            "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw=="
+        },
+        "micromark-util-html-tag-name": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+            "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q=="
+        },
+        "micromark-util-normalize-identifier": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+            "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+            "requires": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-resolve-all": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+            "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+            "requires": {
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-sanitize-uri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+            "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-encode": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-subtokenize": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+            "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+            "requires": {
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "uvu": "^0.5.0"
+            }
+        },
+        "micromark-util-symbol": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+            "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag=="
+        },
+        "micromark-util-types": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+            "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="
+        },
+        "micromatch": {
+            "version": "4.0.5",
+            "dev": true,
+            "requires": {
+                "braces": "^3.0.2",
+                "picomatch": "^2.3.1"
+            }
+        },
+        "mime-db": {
+            "version": "1.52.0",
+            "dev": true,
+            "peer": true
+        },
+        "mime-types": {
+            "version": "2.1.35",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "mime-db": "1.52.0"
+            }
+        },
+        "minimatch": {
+            "version": "3.1.2",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.8"
+        },
+        "mkdirp": {
+            "version": "0.5.6",
+            "requires": {
+                "minimist": "^1.2.6"
+            }
+        },
+        "monaco-editor": {
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.44.0.tgz",
+            "integrity": "sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q==",
+            "peer": true
+        },
+        "mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
+        },
+        "ms": {
+            "version": "2.1.2"
+        },
+        "nanoid": {
+            "version": "3.3.6"
+        },
+        "neo-async": {
+            "version": "2.6.2",
+            "dev": true,
+            "peer": true
+        },
+        "node-releases": {
+            "version": "2.0.10"
+        },
+        "nth-check": {
+            "version": "1.0.2",
+            "requires": {
+                "boolbase": "~1.0.0"
+            }
+        },
+        "object-assign": {
+            "version": "4.1.1"
+        },
+        "object-inspect": {
+            "version": "1.12.3"
+        },
+        "object-is": {
+            "version": "1.1.5",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "object-keys": {
+            "version": "1.1.1"
+        },
+        "object.assign": {
+            "version": "4.1.4",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "has-symbols": "^1.0.3",
+                "object-keys": "^1.1.1"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.1.5",
+            "requires": {
+                "array.prototype.reduce": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            }
+        },
+        "object.values": {
+            "version": "1.1.6",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "parent-module": {
+            "version": "1.0.1",
+            "requires": {
+                "callsites": "^3.0.0"
+            }
+        },
+        "parse-entities": {
+            "version": "2.0.0",
+            "requires": {
+                "character-entities": "^1.0.0",
+                "character-entities-legacy": "^1.0.0",
+                "character-reference-invalid": "^1.0.0",
+                "is-alphanumerical": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-hexadecimal": "^1.0.0"
+            }
+        },
+        "parse-json": {
+            "version": "5.2.0",
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            }
+        },
+        "path-browserify": {
+            "version": "1.0.1"
+        },
+        "path-is-absolute": {
+            "version": "1.0.1"
+        },
+        "path-parse": {
+            "version": "1.0.7"
+        },
+        "path-type": {
+            "version": "4.0.0"
+        },
+        "picocolors": {
+            "version": "1.0.0"
+        },
+        "picomatch": {
+            "version": "2.3.1",
+            "dev": true
+        },
+        "postcss": {
+            "version": "8.4.31",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+            "requires": {
+                "nanoid": "^3.3.6",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "postcss-value-parser": {
+            "version": "3.3.1"
+        },
+        "prettier": {
+            "version": "2.8.7"
+        },
+        "prismjs": {
+            "version": "1.29.0"
+        },
+        "prop-types": {
+            "version": "15.8.1",
+            "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+            },
+            "dependencies": {
+                "react-is": {
+                    "version": "16.13.1"
+                }
+            }
+        },
+        "property-information": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.3.0.tgz",
+            "integrity": "sha512-gVNZ74nqhRMiIUYWGQdosYetaKc83x8oT41a0LlV3AAFCAZwCpg4vmGkq8t34+cUhp3cnM4XDiU/7xlgK7HGrg=="
+        },
+        "punycode": {
+            "version": "2.3.0"
+        },
+        "q": {
+            "version": "1.5.1"
+        },
+        "raf-schd": {
+            "version": "4.0.3"
+        },
+        "randombytes": {
+            "version": "2.1.0",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "react": {
+            "version": "18.2.0",
+            "requires": {
+                "loose-envify": "^1.1.0"
+            }
+        },
+        "react-apexcharts": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/react-apexcharts/-/react-apexcharts-1.4.1.tgz",
+            "integrity": "sha512-G14nVaD64Bnbgy8tYxkjuXEUp/7h30Q0U33xc3AwtGFijJB9nHqOt1a6eG0WBn055RgRg+NwqbKGtqPxy15d0Q==",
+            "requires": {
+                "prop-types": "^15.8.1"
+            }
+        },
+        "react-beautiful-dnd": {
+            "version": "13.1.1",
+            "requires": {
+                "@babel/runtime": "^7.9.2",
+                "css-box-model": "^1.2.0",
+                "memoize-one": "^5.1.1",
+                "raf-schd": "^4.0.2",
+                "react-redux": "^7.2.0",
+                "redux": "^4.0.4",
+                "use-memo-one": "^1.1.1"
+            },
+            "dependencies": {
+                "react-redux": {
+                    "version": "7.2.9",
+                    "requires": {
+                        "@babel/runtime": "^7.15.4",
+                        "@types/react-redux": "^7.1.20",
+                        "hoist-non-react-statics": "^3.3.2",
+                        "loose-envify": "^1.4.0",
+                        "prop-types": "^15.7.2",
+                        "react-is": "^17.0.2"
+                    },
+                    "dependencies": {
+                        "react-is": {
+                            "version": "17.0.2"
+                        }
+                    }
+                }
+            }
+        },
+        "react-datepicker": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.18.0.tgz",
+            "integrity": "sha512-0MYt3HmLbHVk1sw4v+RCbLAVg5TA3jWP7RyjZbo53PC+SEi+pjdgc92lB53ai/ENZaTOhbXmgni9GzvMrorMAw==",
+            "requires": {
+                "@popperjs/core": "^2.11.8",
+                "classnames": "^2.2.6",
+                "date-fns": "^2.30.0",
+                "prop-types": "^15.7.2",
+                "react-onclickoutside": "^6.13.0",
+                "react-popper": "^2.3.0"
+            }
+        },
+        "react-display-name": {
+            "version": "0.2.5"
+        },
+        "react-dom": {
+            "version": "18.2.0",
+            "requires": {
+                "loose-envify": "^1.1.0",
+                "scheduler": "^0.23.0"
+            }
+        },
+        "react-dropzone": {
+            "version": "14.2.3",
+            "dev": true,
+            "requires": {
+                "attr-accept": "^2.2.2",
+                "file-selector": "^0.6.0",
+                "prop-types": "^15.8.1"
+            }
+        },
+        "react-fast-compare": {
+            "version": "3.2.1"
+        },
+        "react-is": {
+            "version": "16.9.0"
+        },
+        "react-jss": {
+            "version": "10.10.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "@emotion/is-prop-valid": "^0.7.3",
+                "css-jss": "10.10.0",
+                "hoist-non-react-statics": "^3.2.0",
+                "is-in-browser": "^1.1.3",
+                "jss": "10.10.0",
+                "jss-preset-default": "10.10.0",
+                "prop-types": "^15.6.0",
+                "shallow-equal": "^1.2.0",
+                "theming": "^3.3.0",
+                "tiny-warning": "^1.0.2"
+            },
+            "dependencies": {
+                "@emotion/is-prop-valid": {
+                    "version": "0.7.3",
+                    "requires": {
+                        "@emotion/memoize": "0.7.1"
+                    },
+                    "dependencies": {
+                        "@emotion/memoize": {
+                            "version": "0.7.1"
+                        }
+                    }
+                }
+            }
+        },
+        "react-lifecycles-compat": {
+            "version": "3.0.4"
+        },
+        "react-markdown": {
+            "version": "8.0.7",
+            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.7.tgz",
+            "integrity": "sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==",
+            "requires": {
+                "@types/hast": "^2.0.0",
+                "@types/prop-types": "^15.0.0",
+                "@types/unist": "^2.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-whitespace": "^2.0.0",
+                "prop-types": "^15.0.0",
+                "property-information": "^6.0.0",
+                "react-is": "^18.0.0",
+                "remark-parse": "^10.0.0",
+                "remark-rehype": "^10.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "style-to-object": "^0.4.0",
+                "unified": "^10.0.0",
+                "unist-util-visit": "^4.0.0",
+                "vfile": "^5.0.0"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.8",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+                    "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+                },
+                "react-is": {
+                    "version": "18.2.0",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+                    "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+                }
+            }
+        },
+        "react-modal": {
+            "version": "3.16.1",
+            "requires": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.7.2",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^4.0.3"
+            }
+        },
+        "react-onclickoutside": {
+            "version": "6.13.0",
+            "requires": {}
+        },
+        "react-popper": {
+            "version": "2.3.0",
+            "requires": {
+                "react-fast-compare": "^3.0.1",
+                "warning": "^4.0.2"
+            }
+        },
+        "react-redux": {
+            "version": "8.1.3",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+            "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+            "requires": {
+                "@babel/runtime": "^7.12.1",
+                "@types/hoist-non-react-statics": "^3.3.1",
+                "@types/use-sync-external-store": "^0.0.3",
+                "hoist-non-react-statics": "^3.3.2",
+                "react-is": "^18.0.0",
+                "use-sync-external-store": "^1.0.0"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.22.5",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.11"
+                    }
+                },
+                "react-is": {
+                    "version": "18.2.0"
+                }
+            }
+        },
+        "react-refresh": {
+            "version": "0.10.0",
+            "dev": true
+        },
+        "react-resize-detector": {
+            "version": "7.1.2",
+            "requires": {
+                "lodash": "^4.17.21"
+            }
+        },
+        "react-router": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.17.0.tgz",
+            "integrity": "sha512-YJR3OTJzi3zhqeJYADHANCGPUu9J+6fT5GLv82UWRGSxu6oJYCKVmxUcaBQuGm9udpWmPsvpme/CdHumqgsoaA==",
+            "requires": {
+                "@remix-run/router": "1.10.0"
+            }
+        },
+        "react-router-dom": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.17.0.tgz",
+            "integrity": "sha512-qWHkkbXQX+6li0COUUPKAUkxjNNqPJuiBd27dVwQGDNsuFBdMbrS6UZ0CLYc4CsbdLYTckn4oB4tGDuPZpPhaQ==",
+            "requires": {
+                "@remix-run/router": "1.10.0",
+                "react-router": "6.17.0"
+            }
+        },
+        "react-select": {
+            "version": "5.7.3",
+            "requires": {
+                "@babel/runtime": "^7.12.0",
+                "@emotion/cache": "^11.4.0",
+                "@emotion/react": "^11.8.1",
+                "@floating-ui/dom": "^1.0.1",
+                "@types/react-transition-group": "^4.4.0",
+                "memoize-one": "^6.0.0",
+                "prop-types": "^15.6.0",
+                "react-transition-group": "^4.3.0",
+                "use-isomorphic-layout-effect": "^1.1.2"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.22.3",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.11"
+                    }
+                },
+                "memoize-one": {
+                    "version": "6.0.0"
+                }
+            }
+        },
+        "react-smooth": {
+            "version": "2.0.2",
+            "requires": {
+                "fast-equals": "^4.0.3",
+                "react-transition-group": "2.9.0"
+            },
+            "dependencies": {
+                "react-transition-group": {
+                    "version": "2.9.0",
+                    "requires": {
+                        "dom-helpers": "^3.4.0",
+                        "loose-envify": "^1.4.0",
+                        "prop-types": "^15.6.2",
+                        "react-lifecycles-compat": "^3.0.4"
+                    },
+                    "dependencies": {
+                        "dom-helpers": {
+                            "version": "3.4.0",
+                            "requires": {
+                                "@babel/runtime": "^7.1.2"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "react-syntax-highlighter": {
+            "version": "15.5.0",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "highlight.js": "^10.4.1",
+                "lowlight": "^1.17.0",
+                "prismjs": "^1.27.0",
+                "refractor": "^3.6.0"
+            }
+        },
+        "react-transition-group": {
+            "version": "4.4.5",
+            "requires": {
+                "@babel/runtime": "^7.5.5",
+                "dom-helpers": "^5.0.1",
+                "loose-envify": "^1.4.0",
+                "prop-types": "^15.6.2"
+            }
+        },
+        "react-virtualized-auto-sizer": {
+            "version": "1.0.20",
+            "requires": {}
+        },
+        "react-window": {
+            "version": "1.8.9",
+            "requires": {
+                "@babel/runtime": "^7.0.0",
+                "memoize-one": ">=3.1.1 <6"
+            }
+        },
+        "reactstrap": {
+            "version": "9.2.0",
+            "requires": {
+                "@babel/runtime": "^7.12.5",
+                "@popperjs/core": "^2.6.0",
+                "classnames": "^2.2.3",
+                "prop-types": "^15.5.8",
+                "react-popper": "^2.2.4",
+                "react-transition-group": "^4.4.2"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.22.5",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.11"
+                    }
+                }
+            }
+        },
+        "recharts": {
+            "version": "2.1.13",
+            "requires": {
+                "classnames": "^2.2.5",
+                "d3-interpolate": "^3.0.1",
+                "d3-scale": "^4.0.2",
+                "d3-shape": "^3.1.0",
+                "eventemitter3": "^4.0.1",
+                "lodash": "^4.17.19",
+                "react-is": "^16.10.2",
+                "react-resize-detector": "^7.1.2",
+                "react-smooth": "^2.0.1",
+                "recharts-scale": "^0.4.4",
+                "reduce-css-calc": "^2.1.8"
+            },
+            "dependencies": {
+                "react-is": {
+                    "version": "16.13.1"
+                }
+            }
+        },
+        "recharts-scale": {
+            "version": "0.4.5",
+            "requires": {
+                "decimal.js-light": "^2.4.1"
+            }
+        },
+        "reduce-css-calc": {
+            "version": "2.1.8",
+            "requires": {
+                "css-unit-converter": "^1.1.1",
+                "postcss-value-parser": "^3.3.0"
+            }
+        },
+        "redux": {
+            "version": "4.2.1",
+            "requires": {
+                "@babel/runtime": "^7.9.2"
+            }
+        },
+        "redux-devtools-extension": {
+            "version": "2.13.9",
+            "dev": true,
+            "requires": {}
+        },
+        "refractor": {
+            "version": "3.6.0",
+            "requires": {
+                "hastscript": "^6.0.0",
+                "parse-entities": "^2.0.0",
+                "prismjs": "~1.27.0"
+            },
+            "dependencies": {
+                "prismjs": {
+                    "version": "1.27.0"
+                }
+            }
+        },
+        "regenerator-runtime": {
+            "version": "0.13.11"
+        },
+        "regexp.prototype.flags": {
+            "version": "1.4.3",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "functions-have-names": "^1.2.2"
+            }
+        },
+        "remark-parse": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
+            "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "mdast-util-from-markdown": "^1.0.0",
+                "unified": "^10.0.0"
+            }
+        },
+        "remark-rehype": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
+            "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+            "requires": {
+                "@types/hast": "^2.0.0",
+                "@types/mdast": "^3.0.0",
+                "mdast-util-to-hast": "^12.1.0",
+                "unified": "^10.0.0"
+            }
+        },
+        "resolve": {
+            "version": "1.22.2",
+            "requires": {
+                "is-core-module": "^2.11.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            }
+        },
+        "resolve-from": {
+            "version": "4.0.0"
+        },
+        "rollup": {
+            "version": "3.27.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.27.2.tgz",
+            "integrity": "sha512-YGwmHf7h2oUHkVBT248x0yt6vZkYQ3/rvE5iQuVBh3WO8GcJ6BNeOkpoX1yMHIiBm18EMLjBPIoUDkhgnyxGOQ==",
+            "dev": true,
+            "requires": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "sade": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+            "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+            "requires": {
+                "mri": "^1.1.0"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "dev": true,
+            "peer": true
+        },
+        "safe-regex-test": {
+            "version": "1.0.0",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.3",
+                "is-regex": "^1.1.4"
+            }
+        },
+        "sax": {
+            "version": "1.2.4"
+        },
+        "scheduler": {
+            "version": "0.23.0",
+            "requires": {
+                "loose-envify": "^1.1.0"
+            }
+        },
+        "schema-utils": {
+            "version": "3.1.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            }
+        },
+        "semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+        },
+        "serialize-javascript": {
+            "version": "6.0.0",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "randombytes": "^2.1.0"
+            }
+        },
+        "shallow-equal": {
+            "version": "1.2.1"
+        },
+        "shallowequal": {
+            "version": "1.1.0"
+        },
+        "side-channel": {
+            "version": "1.0.4",
+            "requires": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            }
+        },
+        "source-map": {
+            "version": "0.5.7"
+        },
+        "source-map-js": {
+            "version": "1.0.2"
+        },
+        "source-map-support": {
+            "version": "0.5.21",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "dev": true,
+                    "peer": true
+                }
+            }
+        },
+        "space-separated-tokens": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+            "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
+        },
+        "sprintf-js": {
+            "version": "1.0.3"
+        },
+        "stable": {
+            "version": "0.1.8"
+        },
+        "state-local": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+            "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
+        },
+        "string.prototype.trim": {
+            "version": "1.2.7",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.6",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.6",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            }
+        },
+        "style-to-object": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.2.tgz",
+            "integrity": "sha512-1JGpfPB3lo42ZX8cuPrheZbfQ6kqPPnPHlKMyeRYtfKD+0jG+QsXgXN57O/dvJlzlB2elI6dGmrPnl5VPQFPaA==",
+            "requires": {
+                "inline-style-parser": "0.1.1"
+            }
+        },
+        "styled-components": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.0.tgz",
+            "integrity": "sha512-VWNfYYBuXzuLS/QYEeoPgMErP26WL+dX9//rEh80B2mmlS1yRxRxuL5eax4m6ybYEUoHWlTy2XOU32767mlMkg==",
+            "requires": {
+                "@emotion/is-prop-valid": "^1.2.1",
+                "@emotion/unitless": "^0.8.0",
+                "@types/stylis": "^4.0.2",
+                "css-to-react-native": "^3.2.0",
+                "csstype": "^3.1.2",
+                "postcss": "^8.4.31",
+                "shallowequal": "^1.1.0",
+                "stylis": "^4.3.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "styled-system": {
+            "version": "5.1.5",
+            "requires": {
+                "@styled-system/background": "^5.1.2",
+                "@styled-system/border": "^5.1.5",
+                "@styled-system/color": "^5.1.2",
+                "@styled-system/core": "^5.1.2",
+                "@styled-system/flexbox": "^5.1.2",
+                "@styled-system/grid": "^5.1.2",
+                "@styled-system/layout": "^5.1.2",
+                "@styled-system/position": "^5.1.2",
+                "@styled-system/shadow": "^5.1.2",
+                "@styled-system/space": "^5.1.2",
+                "@styled-system/typography": "^5.1.2",
+                "@styled-system/variant": "^5.1.5",
+                "object-assign": "^4.1.1"
+            }
+        },
+        "stylis": {
+            "version": "4.3.0"
+        },
+        "supports-color": {
+            "version": "7.2.0",
+            "requires": {
+                "has-flag": "^4.0.0"
+            }
+        },
+        "supports-preserve-symlinks-flag": {
+            "version": "1.0.0"
+        },
+        "svg-parser": {
+            "version": "2.0.4"
+        },
+        "svg.draggable.js": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz",
+            "integrity": "sha512-JzNHBc2fLQMzYCZ90KZHN2ohXL0BQJGQimK1kGk6AvSeibuKcIdDX9Kr0dT9+UJ5O8nYA0RB839Lhvk4CY4MZw==",
+            "requires": {
+                "svg.js": "^2.0.1"
+            }
+        },
+        "svg.easing.js": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/svg.easing.js/-/svg.easing.js-2.0.0.tgz",
+            "integrity": "sha512-//ctPdJMGy22YoYGV+3HEfHbm6/69LJUTAqI2/5qBvaNHZ9uUFVC82B0Pl299HzgH13rKrBgi4+XyXXyVWWthA==",
+            "requires": {
+                "svg.js": ">=2.3.x"
+            }
+        },
+        "svg.filter.js": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/svg.filter.js/-/svg.filter.js-2.0.2.tgz",
+            "integrity": "sha512-xkGBwU+dKBzqg5PtilaTb0EYPqPfJ9Q6saVldX+5vCRy31P6TlRCP3U9NxH3HEufkKkpNgdTLBJnmhDHeTqAkw==",
+            "requires": {
+                "svg.js": "^2.2.5"
+            }
+        },
+        "svg.js": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/svg.js/-/svg.js-2.7.1.tgz",
+            "integrity": "sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA=="
+        },
+        "svg.pathmorphing.js": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/svg.pathmorphing.js/-/svg.pathmorphing.js-0.1.3.tgz",
+            "integrity": "sha512-49HWI9X4XQR/JG1qXkSDV8xViuTLIWm/B/7YuQELV5KMOPtXjiwH4XPJvr/ghEDibmLQ9Oc22dpWpG0vUDDNww==",
+            "requires": {
+                "svg.js": "^2.4.0"
+            }
+        },
+        "svg.resize.js": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/svg.resize.js/-/svg.resize.js-1.4.3.tgz",
+            "integrity": "sha512-9k5sXJuPKp+mVzXNvxz7U0uC9oVMQrrf7cFsETznzUDDm0x8+77dtZkWdMfRlmbkEEYvUn9btKuZ3n41oNA+uw==",
+            "requires": {
+                "svg.js": "^2.6.5",
+                "svg.select.js": "^2.1.2"
+            },
+            "dependencies": {
+                "svg.select.js": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-2.1.2.tgz",
+                    "integrity": "sha512-tH6ABEyJsAOVAhwcCjF8mw4crjXSI1aa7j2VQR8ZuJ37H2MBUbyeqYr5nEO7sSN3cy9AR9DUwNg0t/962HlDbQ==",
+                    "requires": {
+                        "svg.js": "^2.2.5"
+                    }
+                }
+            }
+        },
+        "svg.select.js": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-3.0.1.tgz",
+            "integrity": "sha512-h5IS/hKkuVCbKSieR9uQCj9w+zLHoPh+ce19bBYyqF53g6mnPB8sAtIbe1s9dh2S2fCmYX2xel1Ln3PJBbK4kw==",
+            "requires": {
+                "svg.js": "^2.6.5"
+            }
+        },
+        "svgi": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/svgi/-/svgi-1.1.2.tgz",
+            "integrity": "sha512-a+p8kvoai9/2UpPPYR/4maLIXWWfLWdVxu8svhKgDDANL39cWrWBm9k03x92zpP4hmbe/Mb13DDNnXQiYFnzHw==",
+            "requires": {
+                "ascii-tree": "^0.3.0",
+                "cli-table": "^0.3.11",
+                "colors": "^1.4.0",
+                "commander": "8.3.0",
+                "filesize": "^8.0.7",
+                "js-yaml": "^4.1.0",
+                "xml2js": "^0.6.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "8.3.0"
+                }
+            }
+        },
+        "svgo": {
+            "version": "1.3.2",
+            "requires": {
+                "chalk": "^2.4.1",
+                "coa": "^2.0.2",
+                "css-select": "^2.0.0",
+                "css-select-base-adapter": "^0.1.1",
+                "css-tree": "1.0.0-alpha.37",
+                "csso": "^4.0.2",
+                "js-yaml": "^3.13.1",
+                "mkdirp": "~0.5.1",
+                "object.values": "^1.1.0",
+                "sax": "~1.2.4",
+                "stable": "^0.1.8",
+                "unquote": "~1.1.1",
+                "util.promisify": "~1.0.0"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    },
+                    "dependencies": {
+                        "ansi-styles": {
+                            "version": "3.2.1",
+                            "requires": {
+                                "color-convert": "^1.9.0"
+                            },
+                            "dependencies": {
+                                "color-convert": {
+                                    "version": "1.9.3",
+                                    "requires": {
+                                        "color-name": "1.1.3"
+                                    },
+                                    "dependencies": {
+                                        "color-name": {
+                                            "version": "1.1.3"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+                },
+                "js-yaml": {
+                    "version": "3.14.1",
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "argparse": {
+                            "version": "1.0.10",
+                            "requires": {
+                                "sprintf-js": "~1.0.2"
+                            }
+                        }
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "symbol-observable": {
+            "version": "1.2.0"
+        },
+        "tapable": {
+            "version": "2.2.1",
+            "dev": true
+        },
+        "terser": {
+            "version": "5.15.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@jridgewell/source-map": "^0.3.2",
+                "acorn": "^8.5.0",
+                "commander": "^2.20.0",
+                "source-map-support": "~0.5.20"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.20.3",
+                    "dev": true,
+                    "peer": true
+                }
+            }
+        },
+        "terser-webpack-plugin": {
+            "version": "5.3.6",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@jridgewell/trace-mapping": "^0.3.14",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^3.1.1",
+                "serialize-javascript": "^6.0.0",
+                "terser": "^5.14.1"
+            }
+        },
+        "theming": {
+            "version": "3.3.0",
+            "requires": {
+                "hoist-non-react-statics": "^3.3.0",
+                "prop-types": "^15.5.8",
+                "react-display-name": "^0.2.4",
+                "tiny-warning": "^1.0.2"
+            }
+        },
+        "tiny-invariant": {
+            "version": "1.3.1"
+        },
+        "tiny-warning": {
+            "version": "1.0.3"
+        },
+        "to-fast-properties": {
+            "version": "2.0.0"
+        },
+        "to-regex-range": {
+            "version": "5.0.1",
+            "dev": true,
+            "requires": {
+                "is-number": "^7.0.0"
+            }
+        },
+        "trim-lines": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+            "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
+        },
+        "trough": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+            "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+        },
+        "ts-loader": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.0.tgz",
+            "integrity": "sha512-LLlB/pkB4q9mW2yLdFMnK3dEHbrBjeZTYguaaIfusyojBgAGf5kF+O6KcWqiGzWqHk0LBsoolrp4VftEURhybg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.1.0",
+                "enhanced-resolve": "^5.0.0",
+                "micromatch": "^4.0.0",
+                "semver": "^7.3.4",
+                "source-map": "^0.7.4"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.7.4",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+                    "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+                    "dev": true
+                }
+            }
+        },
+        "tslib": {
+            "version": "2.6.0"
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+        },
+        "typed-array-length": {
+            "version": "1.0.4",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "is-typed-array": "^1.1.9"
+            }
+        },
+        "typescript": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+            "dev": true
+        },
+        "ua-parser-js": {
+            "version": "1.0.36",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.36.tgz",
+            "integrity": "sha512-znuyCIXzl8ciS3+y3fHJI/2OhQIXbXw9MWC/o3qwyR+RGppjZHrM27CGFSKCJXi2Kctiz537iOu2KnXs1lMQhw=="
+        },
+        "unbox-primitive": {
+            "version": "1.0.2",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-bigints": "^1.0.2",
+                "has-symbols": "^1.0.3",
+                "which-boxed-primitive": "^1.0.2"
+            }
+        },
+        "unified": {
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "bail": "^2.0.0",
+                "extend": "^3.0.0",
+                "is-buffer": "^2.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^5.0.0"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.8",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+                    "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+                }
+            }
+        },
+        "unist-util-generated": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
+            "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A=="
+        },
+        "unist-util-is": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+            "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+            "requires": {
+                "@types/unist": "^2.0.0"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.8",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+                    "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+                }
+            }
+        },
+        "unist-util-position": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
+            "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
+            "requires": {
+                "@types/unist": "^2.0.0"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.8",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+                    "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+                }
+            }
+        },
+        "unist-util-stringify-position": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+            "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+            "requires": {
+                "@types/unist": "^2.0.0"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.8",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+                    "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+                }
+            }
+        },
+        "unist-util-visit": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+            "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "unist-util-is": "^5.0.0",
+                "unist-util-visit-parents": "^5.1.1"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.8",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+                    "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+                }
+            }
+        },
+        "unist-util-visit-parents": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+            "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "unist-util-is": "^5.0.0"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.8",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+                    "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+                }
+            }
+        },
+        "unquote": {
+            "version": "1.1.1"
+        },
+        "update-browserslist-db": {
+            "version": "1.0.10",
+            "requires": {
+                "escalade": "^3.1.1",
+                "picocolors": "^1.0.0"
+            }
+        },
+        "uri-js": {
+            "version": "4.4.1",
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "use-isomorphic-layout-effect": {
+            "version": "1.1.2",
+            "requires": {}
+        },
+        "use-memo-one": {
+            "version": "1.1.3",
+            "requires": {}
+        },
+        "use-sync-external-store": {
+            "version": "1.2.0",
+            "requires": {}
+        },
+        "util": {
+            "version": "0.12.5",
+            "requires": {
+                "inherits": "^2.0.3",
+                "is-arguments": "^1.0.4",
+                "is-generator-function": "^1.0.7",
+                "is-typed-array": "^1.1.3",
+                "which-typed-array": "^1.1.2"
+            }
+        },
+        "util.promisify": {
+            "version": "1.0.1",
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.2",
+                "has-symbols": "^1.0.1",
+                "object.getownpropertydescriptors": "^2.1.0"
+            }
+        },
+        "uvu": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+            "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+            "requires": {
+                "dequal": "^2.0.0",
+                "diff": "^5.0.0",
+                "kleur": "^4.0.3",
+                "sade": "^1.7.3"
+            }
+        },
+        "validate.io-array": {
+            "version": "1.0.6"
+        },
+        "validate.io-function": {
+            "version": "1.0.2"
+        },
+        "validate.io-integer": {
+            "version": "1.0.5",
+            "requires": {
+                "validate.io-number": "^1.0.3"
+            }
+        },
+        "validate.io-integer-array": {
+            "version": "1.0.0",
+            "requires": {
+                "validate.io-array": "^1.0.3",
+                "validate.io-integer": "^1.0.4"
+            }
+        },
+        "validate.io-number": {
+            "version": "1.0.3"
+        },
+        "vfile": {
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+            "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "is-buffer": "^2.0.0",
+                "unist-util-stringify-position": "^3.0.0",
+                "vfile-message": "^3.0.0"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.8",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+                    "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+                }
+            }
+        },
+        "vfile-message": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+            "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "unist-util-stringify-position": "^3.0.0"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.8",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+                    "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+                }
+            }
+        },
+        "vite": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
+            "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+            "dev": true,
+            "requires": {
+                "esbuild": "^0.18.10",
+                "fsevents": "~2.3.2",
+                "postcss": "^8.4.27",
+                "rollup": "^3.27.1"
+            }
+        },
+        "warning": {
+            "version": "4.0.3",
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
+        "watchpack": {
+            "version": "2.4.0",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            }
+        },
+        "webpack": {
+            "version": "5.76.1",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/wasm-edit": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "acorn": "^8.7.1",
+                "acorn-import-assertions": "^1.7.6",
+                "browserslist": "^4.14.5",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^5.10.0",
+                "es-module-lexer": "^0.9.0",
+                "eslint-scope": "5.1.1",
+                "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.2.9",
+                "json-parse-even-better-errors": "^2.3.1",
+                "loader-runner": "^4.2.0",
+                "mime-types": "^2.1.27",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^3.1.0",
+                "tapable": "^2.1.1",
+                "terser-webpack-plugin": "^5.1.3",
+                "watchpack": "^2.4.0",
+                "webpack-sources": "^3.2.3"
+            }
+        },
+        "webpack-sources": {
+            "version": "3.2.3",
+            "dev": true,
+            "peer": true
+        },
+        "which-boxed-primitive": {
+            "version": "1.0.2",
+            "requires": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            }
+        },
+        "which-typed-array": {
+            "version": "1.1.9",
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0",
+                "is-typed-array": "^1.1.10"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2"
+        },
+        "xml2js": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+            "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            }
+        },
+        "xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+        },
+        "xtend": {
+            "version": "4.0.2"
+        },
+        "xterm": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.2.1.tgz",
+            "integrity": "sha512-cs5Y1fFevgcdoh2hJROMVIWwoBHD80P1fIP79gopLHJIE4kTzzblanoivxTiQ4+92YM9IxS36H1q0MxIJXQBcA=="
+        },
+        "xterm-addon-fit": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.7.0.tgz",
+            "integrity": "sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==",
+            "requires": {}
+        },
+        "yallist": {
+            "version": "4.0.0",
+            "dev": true
+        },
+        "yaml": {
+            "version": "1.10.2"
         }
     }
 }

--- a/frontend-web/webclient/package.json
+++ b/frontend-web/webclient/package.json
@@ -16,6 +16,7 @@
     },
     "dependencies": {
         "@ginkgo-bioworks/react-json-schema-form-builder": "2.10.2",
+        "@monaco-editor/react": "^4.6.0",
         "@novnc/novnc": "1.4.0",
         "@rjsf/core": "4.2.3",
         "@svgr/cli": "5.5.0",
@@ -27,6 +28,7 @@
         "fuse.js": "6.6.2",
         "jsrsasign": "10.8.6",
         "localforage": "1.10.0",
+        "magic-bytes.js": "^1.5.0",
         "path-browserify": "1.0.1",
         "react": "18.2.0",
         "react-apexcharts": "^1.4.1",


### PR DESCRIPTION
Improves preview of files, with the two main changes:

 - Use magic bytes ([magic-bytes.js](https://github.com/LarsKoelpin/magic-bytes)) to determine the file type, instead of the file extension. Preview of files should now work in most cases, independently of the extension. 
 - Switch to [monaco-editor](https://microsoft.github.io/monaco-editor/) for preview of text (set to read-only mode). The editor includes more features like file-search and better performance. The 100kb limit on syntax highlighting has been removed since it seems monaco has build-in limits. Monaco is not able to determine the file type, so we try to guess the file type from the extension and pass it to monaco.

fixes #4066 