### PR TITLE
ran a single test bbut no error.

### DIFF
--- a/backend/app-store-service/api/src/main/kotlin/api/ApplicationParameter.kt
+++ b/backend/app-store-service/api/src/main/kotlin/api/ApplicationParameter.kt
@@ -224,9 +224,9 @@ sealed class ApplicationParameter {
         override var name: String = "",
         override val title: String = "",
         override val description: String = "",
+        override val optional: Boolean// = false
     ) : ApplicationParameter() {
         override val defaultValue: JsonElement? = null
-        override val optional = false
     }
 
     @Serializable
@@ -257,8 +257,8 @@ sealed class ApplicationParameter {
         override var name: String = "",
         override val title: String = "",
         override val description: String = "",
+        override val optional: Boolean = false
     ) : ApplicationParameter() {
         override val defaultValue: JsonElement? = null
-        override val optional = false
     }
 }

--- a/backend/app-store-service/src/main/kotlin/app/store/api/ApplicationDescription.kt
+++ b/backend/app-store-service/src/main/kotlin/app/store/api/ApplicationDescription.kt
@@ -431,7 +431,8 @@ sealed class ApplicationDescription(val application: String) {
                         ApplicationParameter.Ingress(
                             param.name,
                             param.title,
-                            param.description
+                            param.description,
+                            param.optional
                         )
                     }
                     is ApplicationParameterYaml.InputDirectory -> {

--- a/backend/app-store-service/src/main/kotlin/app/store/api/ApplicationParameterYaml.kt
+++ b/backend/app-store-service/src/main/kotlin/app/store/api/ApplicationParameterYaml.kt
@@ -127,9 +127,9 @@ sealed class ApplicationParameterYaml {
         override var name: String = "",
         override val title: String = "",
         override val description: String = "",
+        override val optional: Boolean = false,
     ) : ApplicationParameterYaml() {
         override val defaultValue: Any? = null
-        override val optional = false
     }
 
     data class LicenseServer(
@@ -146,8 +146,8 @@ sealed class ApplicationParameterYaml {
         override var name: String = "",
         override val title: String = "",
         override val description: String = "",
+        override val optional:Boolean = false
     ) : ApplicationParameterYaml() {
         override val defaultValue: Any? = null
-        override val optional = false
     }
 }


### PR DESCRIPTION
tested with a single instance of coder

```
invocation:
   - type: var
    vars: pub_link


parameters:
  pub_link:
    title: "Select link to use"
    type: ingress
```

optional was set automatically to false