### PR TITLE
Search searches on empty search

### DIFF
--- a/frontend-web/webclient/app/ui-components/ResourceBrowser.tsx
+++ b/frontend-web/webclient/app/ui-components/ResourceBrowser.tsx
@@ -566,9 +566,6 @@ export class ResourceBrowser<T> {
             input.onkeyup = e => {
                 if (e.key === "Enter") {
                     this.searchQuery = input.value;
-                    if (!this.searchQuery) {
-                        return;
-                    }
                     this.dispatchMessage("search", fn => fn(this.searchQuery));
                 }
             };


### PR DESCRIPTION
Attempted to fix #2980 but it seems already fixed.
However noticed that the search bar does not show all drives/shares and ignores enter, when search field is empty. So changed this