### PR TITLE
Fix to exprie times on VMs

### DIFF
--- a/backend/app-orchestrator-service/src/main/kotlin/services/JobVerificationService.kt
+++ b/backend/app-orchestrator-service/src/main/kotlin/services/JobVerificationService.kt
@@ -2,10 +2,7 @@ package dk.sdu.cloud.app.orchestrator.services
 
 import dk.sdu.cloud.ActorAndProject
 import dk.sdu.cloud.app.orchestrator.api.JobSpecification
-import dk.sdu.cloud.app.store.api.AppParameterValue
-import dk.sdu.cloud.app.store.api.Application
-import dk.sdu.cloud.app.store.api.ApplicationParameter
-import dk.sdu.cloud.app.store.api.SshDescription
+import dk.sdu.cloud.app.store.api.*
 import dk.sdu.cloud.calls.HttpStatusCode
 import dk.sdu.cloud.calls.RPCException
 import dk.sdu.cloud.file.orchestrator.api.extractPathMetadata
@@ -38,6 +35,9 @@ class JobVerificationService(
         if (specification.timeAllocation != null) {
             if (specification.timeAllocation!!.toMillis() <= 0) {
                 throw JobException.VerificationError("Time allocated for job is too short.")
+            }
+            if (application.invocation.tool.tool?.description?.backend == ToolBackend.VIRTUAL_MACHINE) {
+                specification.timeAllocation = null
             }
         }
 


### PR DESCRIPTION
Check if job is VM and set allocated time to null if set. Frontend currently sets automatically 1 hour on create

Fixes #4090

Tested on launcher env with changing directly in DB with normal app and with code (by excluding new if)
If statement should only catch VMs after tested