### PR TITLE
Change email notifications from create job page

### DIFF
--- a/frontend-web/webclient/app/UserSettings/ChangeEmailSettings.tsx
+++ b/frontend-web/webclient/app/UserSettings/ChangeEmailSettings.tsx
@@ -11,7 +11,7 @@ import retrieveEmailSettings = mail.retrieveEmailSettings;
 import toggleEmailSettings = mail.toggleEmailSettings;
 import HexSpin from "@/LoadingIcon/LoadingIcon";
 
-interface UserDetailsState {
+export interface UserDetailsState {
     settings: EmailSettings
 }
 
@@ -62,7 +62,7 @@ const initialState: UserDetailsState = {
     settings: defaultEmailSettings
 };
 
-type UpdatePlaceholdersEmailSettings = PayloadAction<"UpdatePlaceholdersEmailSettings", UserDetailsState>;
+export type UpdatePlaceholdersEmailSettings = PayloadAction<"UpdatePlaceholdersEmailSettings", UserDetailsState>;
 
 const reducer = (state: UserDetailsState, action: UpdatePlaceholdersEmailSettings): UserDetailsState => {
     switch (action.type) {


### PR DESCRIPTION
fixes #4179 

 - Added the option to "Notify me  when a job stops"
 - Link the select box to the backend
 - Automatically detect what the current setting is, and set as default value

This changes the global settings, not on a per-job basis, but I think it should be clear from the wording and behavior.