### PR TITLE
Grant Transfer update

### DIFF
--- a/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
+++ b/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
@@ -414,7 +414,9 @@ class GrantsV2Service(
                             select f.application_id as id
                             from
                                 "grant".forms f
-                                join max_revision_and_id mri on f.application_id = mri.id and f.revision_number = mri.max_revision
+                                join max_revision_and_id mri on
+                                    f.application_id = mri.id
+                                    and f.revision_number = mri.max_revision
                                 join project.projects p on f.recipient = p.id
                                 left join project.project_members pm on p.id = pm.project_id
                             where

--- a/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
+++ b/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
@@ -279,7 +279,7 @@ class GrantsV2Service(
         request: GrantsV2.Transfer.Request,
     ) {
         val project = actorAndProject.project ?: throw RPCException("Unknown project", HttpStatusCode.BadRequest)
-        //If source and target is same project just skip everything and say OK
+        // If source and target is same project just skip everything and say OK
         if (project == request.target) return
         modify(actorAndProject, request.applicationId) {
             runCommand(Command.Transfer(request.comment, project, request.target))

--- a/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
+++ b/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
@@ -369,8 +369,9 @@ class GrantsV2Service(
                     with
                         max_revision_and_id as (
                             select a.id, max(r.revision_number) max_revision
-                            from "grant".applications a join
-                                "grant".revisions r on a.id = r.application_id
+                            from
+                                "grant".applications a
+                                join "grant".revisions r on a.id = r.application_id
                             group by id
                             order by id
                         ),

--- a/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
+++ b/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
@@ -1149,7 +1149,7 @@ class GrantsV2Service(
                         ?: throw RPCException("Unknown project? ${command.targetProjectId}", HttpStatusCode.BadRequest)
 
 
-                    //Note(Henrik) Not possible through front-end, but it can be done from backend and it should not
+                    // NOTE(Henrik): Not possible through front-end, but it can be done from backend and it should not
                     // be possible to transfer a grant if the transferor already has handled the application.
                     val currentApprovalStateOfTransferor = application.status.stateBreakdown.find { it.projectId == command.sourceProjectId }?.state
                         ?: throw RPCException("Unknown source project? ${command.sourceProjectId}", HttpStatusCode.BadRequest)

--- a/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
+++ b/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
@@ -390,7 +390,8 @@ class GrantsV2Service(
                         accessible_as_sender as (
                             select app.id as id
                             from
-                                "grant".applications app join max_revision_and_id mri on app.id = mri.id
+                                "grant".applications app
+                                join max_revision_and_id mri on app.id = mri.id
                                 join "grant".forms f on f.application_id = app.id and mri.max_revision = f.revision_number
                             where
                                 f.application_id = app.id

--- a/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
+++ b/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
@@ -378,7 +378,9 @@ class GrantsV2Service(
                             select rr.application_id as id
                             from
                                 "grant".requested_resources rr
-                                join max_revision_and_id mri on rr.application_id = id and rr.revision_number = max_revision
+                                join max_revision_and_id mri on
+                                    rr.application_id = id
+                                    and rr.revision_number = max_revision
                                 join project.project_members pm on rr.grant_giver = pm.project_id
                             where
                                 (pm.role = 'ADMIN' or pm.role = 'PI')

--- a/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
+++ b/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
@@ -1501,8 +1501,12 @@ class GrantsV2Service(
                             },
                             """
                                 update "grant".grant_giver_approvals
-                                set project_id = :new_id, project_title = :new_title
-                                where application_id = :application_id and project_id = :old_id
+                                set
+                                    project_id = :new_id,
+                                    project_title = :new_title
+                                where
+                                    application_id = :application_id
+                                    and project_id = :old_id
                             """
                         )
                     }

--- a/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
+++ b/backend/accounting-service/src/main/kotlin/services/grants/GrantsV2Service.kt
@@ -1194,7 +1194,6 @@ class GrantsV2Service(
                         application.status.copy(stateBreakdown = newBreakdown)
                     )
 
-                    //Cleanup Status Grant Giver Approval State in DB
                     actionQueue.add(
                         Action.TransferCleanup(
                             oldSource = command.sourceProjectId,

--- a/frontend-web/webclient/app/Grants/Editor.tsx
+++ b/frontend-web/webclient/app/Grants/Editor.tsx
@@ -2189,7 +2189,7 @@ const CommentSection: React.FunctionComponent<{
     useLayoutEffect(() => {
         const scrollingBox = scrollingRef.current;
         if (!scrollingBox) return;
-        scrollingBox.scrollTop = scrollingBox.scrollHeight
+        scrollingBox.scrollTop = scrollingBox.scrollHeight;
     }, [entries]);
 
     const onKeyDown = useCallback<React.KeyboardEventHandler>(ev => {

--- a/frontend-web/webclient/app/Grants/Editor.tsx
+++ b/frontend-web/webclient/app/Grants/Editor.tsx
@@ -81,25 +81,21 @@ interface EditorState {
         referenceIds: string[];
         comments?: Grants.Comment[];
     };
-    possibleTransfers: {
-        id: string;
-        title: string;
-        description: string;
-        template: string;
-        checked: boolean;
-    }[];
-    allocators: {
-        id: string;
-        title: string;
-        description: string;
-        template: string;
-        checked: boolean;
-    }[];
+    possibleTransfers: Allocators[];
+    allocators: Allocators[];
 
     application: ApplicationSection[];
     applicationDocument: Record<string, string>;
 
     resources: Record<string, ResourceCategory[]>;
+}
+
+interface Allocators {
+    id: string;
+    title: string;
+    description: string;
+    template: string;
+    checked: boolean;
 }
 
 interface SimpleRevision {

--- a/frontend-web/webclient/app/Grants/Editor.tsx
+++ b/frontend-web/webclient/app/Grants/Editor.tsx
@@ -81,7 +81,13 @@ interface EditorState {
         referenceIds: string[];
         comments?: Grants.Comment[];
     };
-
+    possibleTransfers: {
+        id: string;
+        title: string;
+        description: string;
+        template: string;
+        checked: boolean;
+    }[];
     allocators: {
         id: string;
         title: string;
@@ -124,6 +130,7 @@ const defaultState: EditorState = {
         },
         durationInMonths: 12
     },
+    possibleTransfers: [],
     application: [],
     applicationDocument: {},
     loading: false,
@@ -216,6 +223,7 @@ function stateReducer(state: EditorState, action: EditorAction): EditorState {
         case "AllocatorsLoaded": {
             const newAllocators: EditorState["allocators"] = state.allocators
                 .filter(it => action.allocators.some(other => it.id === other.id));
+
             const newResources: EditorState["resources"] = {...state.resources};
 
             let templateKey: keyof Grants.Templates = "newProject";
@@ -287,6 +295,7 @@ function stateReducer(state: EditorState, action: EditorAction): EditorState {
 
             return {
                 ...state,
+                possibleTransfers: newAllocators,
                 allocators: newAllocators,
                 resources: newResources,
                 application: allSections,
@@ -1928,6 +1937,7 @@ export function Editor(): React.ReactNode {
                                             }
                                             state={state.stateDuringEdit?.stateByGrantGiver[it.id]}
                                             allAllocators={state.allocators}
+                                            transfers={state.possibleTransfers}
                                             onTransfer={onTransfer}
                                         />
                                     )}
@@ -2179,7 +2189,7 @@ const CommentSection: React.FunctionComponent<{
     useLayoutEffect(() => {
         const scrollingBox = scrollingRef.current;
         if (!scrollingBox) return;
-        scrollingBox.scrollTop = Number.MAX_SAFE_INTEGER;
+        scrollingBox.scrollTop = scrollingBox.scrollHeight
     }, [entries]);
 
     const onKeyDown = useCallback<React.KeyboardEventHandler>(ev => {
@@ -2307,6 +2317,7 @@ const GrantGiver: React.FunctionComponent<{
     replaceApproval?: React.ReactNode;
     replaceReject?: React.ReactNode;
     allAllocators: EditorState["allocators"];
+    transfers: EditorState["possibleTransfers"];
     onTransfer?: (source: string, jdestination: string, comment: string) => void;
 }> = props => {
     const checkboxId = `check-${props.projectId}`;
@@ -2331,7 +2342,7 @@ const GrantGiver: React.FunctionComponent<{
         if (!props.onTransfer) return;
 
         const result = await transferProject(
-            props.allAllocators.filter(it => !it.checked && it.id !== props.projectId)
+            props.transfers.filter(it => !it.checked && it.id !== props.projectId)
         );
         if (result) {
             props.onTransfer(props.projectId, result.targetId, result.comment);

--- a/frontend-web/webclient/app/Grants/Editor.tsx
+++ b/frontend-web/webclient/app/Grants/Editor.tsx
@@ -2318,7 +2318,7 @@ const GrantGiver: React.FunctionComponent<{
     replaceReject?: React.ReactNode;
     allAllocators: EditorState["allocators"];
     transfers: EditorState["possibleTransfers"];
-    onTransfer?: (source: string, jdestination: string, comment: string) => void;
+    onTransfer?: (source: string, destination: string, comment: string) => void;
 }> = props => {
     const checkboxId = `check-${props.projectId}`;
     const size = 30;


### PR DESCRIPTION
Fixed #4279 . Also made comment section auto scroll down to newest revision or comment.

Only shows transfer options based on grant seekers available grant givers (not included those already in the grant).
Might be a better way for the frontend to show the possible transfer options than the new element "possibleTransfers" identical to "allcoators", but the "allocators" element was filtered and modified to only contain the allocators that was requested for resources in the grant, so it did not contain all possible grant givers of the grant seeker.

Not sure if it should be possible to transfer to a grant giver that is already participating in the grant. If it should be possible should the resources that overlap then just be summed or should something else happen?