### PR TITLE
Fix wrong `next` being passed fetching the next files for large pages

### DIFF
--- a/frontend-web/webclient/app/UCloud/FilesApi.tsx
+++ b/frontend-web/webclient/app/UCloud/FilesApi.tsx
@@ -1424,7 +1424,7 @@ class PreviewVfs implements Vfs {
         }));
 
         if (result.next) {
-            return toVirtualFiles(result).concat(await this.fetchFiles(path, next));
+            return toVirtualFiles(result).concat(await this.fetchFiles(path, result.next));
         }
 
         return toVirtualFiles(result);


### PR DESCRIPTION
Fixes #4510 