### PR TITLE
Fixes #4951

### DIFF
--- a/frontend-web/webclient/app/Files/FileBrowse.tsx
+++ b/frontend-web/webclient/app/Files/FileBrowse.tsx
@@ -327,15 +327,15 @@ function FileBrowse({opts}: {opts?: ResourceBrowserOpts<UFile> & AdditionalResou
                         size?: number
                     }
                 ): UFile => {
-                    const page = browser.cachedData[browser.currentPath] ?? [];
                     let likelyProduct: ProductReference = {id: "", provider: "", category: ""};
-                    if (page.length > 0) likelyProduct = page[0].specification.product;
+                    const drive = collectionCache.retrieveFromCacheOnly(pathComponents(path)[0]);
+                    if (drive) likelyProduct = drive.specification.product;
 
                     let likelyOwner: ResourceOwner = {createdBy: Client.username ?? "", project: Client.projectId};
-                    if (page.length > 0) likelyOwner = page[0].owner;
+                    if (drive) likelyOwner = drive.owner;
 
                     let likelyPermissions: ResourcePermissions = {myself: ["ADMIN", "READ", "EDIT"]};
-                    if (page.length > 0) likelyPermissions = page[0].permissions;
+                    if (drive) likelyPermissions = drive.permissions;
 
                     return {
                         createdAt: opts?.modifiedAt ?? 0,


### PR DESCRIPTION
I need to make sure I'm understanding it correctly, but in the case there are no other files in the drive, there's nothing to fetch from, but a folder can only be created in a drive, that has to exist at that point, so it's better to depend on.