### PR TITLE
Moves the provider check into the `Selection` prop that's used to add buttons.

### DIFF
--- a/frontend-web/webclient/app/Applications/Jobs/Create.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Create.tsx
@@ -901,18 +901,22 @@ export function getProviderField(): string | undefined {
     try {
         const validatedMachineReservation = validateMachineReservation();
         return validatedMachineReservation?.provider;
-    } catch (e) {
+    } catch {
         return undefined;
     }
 }
 
-export function checkProviderMismatch(resource: Resource, resourceType: string): string | false {
-    const provider = getProviderField();
-    const resourceProvider = resource.specification.product.provider;
+export function checkProviderMismatch<T>(provider: string | undefined, resource: T & {specification?: Resource["specification"]}, resourceType: string): string | false {
+    const resourceProvider = resource.specification?.product.provider;
+    if (!resourceProvider) return false;
     if (provider && provider !== resourceProvider) {
         return providerMismatchError(resourceProvider, resourceType);
     }
     return false;
+}
+
+export function checkMachineProviderMismatch(resource: Resource, resourceType: string): string | false {
+    return checkProviderMismatch(getProviderField(), resource, resourceType);
 }
 
 export function providerMismatchError(resourceProvider: string, resourceType: string): string {

--- a/frontend-web/webclient/app/Applications/Jobs/Widgets/GenericFiles.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Widgets/GenericFiles.tsx
@@ -91,7 +91,8 @@ export const FilesParameter: React.FunctionComponent<FilesProps> = props => {
         const selection: Selection<UFile> = {
             text: "Use",
             onClick,
-            show: providerRestriction
+            show: providerRestriction,
+            provider: provider ?? null,
         };
 
         const navigateToFolder = (path: string, projectId?: string) => {

--- a/frontend-web/webclient/app/Applications/Jobs/Widgets/ImportParameters.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Widgets/ImportParameters.tsx
@@ -195,8 +195,9 @@ export function ImportParameters({application, onImport, importDialogOpen, onImp
                                             fetchAndImportParameters(res);
                                             dialogStore.success();
                                         },
-                                        show: res => res.status.type === "FILE" && res.id.endsWith(".json")
-                                    }
+                                        show: res => res.status.type === "FILE" && res.id.endsWith(".json"),
+                                        provider: null
+                                    },
                                 }}
                             />,
                             () => undefined,
@@ -214,7 +215,8 @@ export function ImportParameters({application, onImport, importDialogOpen, onImp
                     onClick(res) {
                         readParsedJSON(res.status.jobParametersJson);
                         dialogStore.success();
-                    }
+                    },
+                    provider: null
                 },
                 additionalFilters: {filterApplication: application.metadata.name, includeParameters: "true"},
             }} />

--- a/frontend-web/webclient/app/Applications/Jobs/Widgets/Ingress.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Widgets/Ingress.tsx
@@ -9,7 +9,7 @@ import AppParameterValueNS = compute.AppParameterValueNS;
 import {noopCall, useCloudCommand} from "@/Authentication/DataHook";
 import PublicLinkApi, {PublicLink} from "@/UCloud/PublicLinkApi";
 import {snackbarStore} from "@/Snackbar/SnackbarStore";
-import {checkProviderMismatch} from "../Create";
+import {checkProviderMismatch, getProviderField} from "../Create";
 import {PublicLinkBrowse} from "@/Applications/PublicLinks/PublicLinkBrowse";
 import {ApplicationParameterNS} from "@/Applications/AppStoreApi";
 import {dialogStore} from "@/Dialog/DialogStore";
@@ -31,10 +31,10 @@ export const IngressParameter: React.FunctionComponent<IngressProps> = props => 
                         dialogStore.success();
                     },
                     show(res) {
-                        const errorMessage = checkProviderMismatch(res, "Public links");
-                        if (errorMessage) return errorMessage;
-                        return res.status.boundTo.length === 0;
-                    }
+                        if (res.status.boundTo.length === 0) return true;
+                        else return "Public link already in use";
+                    },
+                    provider: getProviderField() ?? null,
                 },
                 isModal: true,
                 additionalFilters: filters

--- a/frontend-web/webclient/app/Applications/Jobs/Widgets/License.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Widgets/License.tsx
@@ -6,7 +6,7 @@ import AppParameterValueNS = compute.AppParameterValueNS;
 import {useCallback} from "react";
 import {largeModalStyle} from "@/Utilities/ModalUtilities";
 import {License} from "@/UCloud/LicenseApi";
-import {checkProviderMismatch} from "../Create";
+import {checkProviderMismatch, getProviderField} from "../Create";
 import {Input} from "@/ui-components";
 import {LicenseBrowse} from "@/Applications/LicenseBrowse";
 import {ApplicationParameterNS} from "@/Applications/AppStoreApi";
@@ -19,6 +19,7 @@ interface LicenseProps extends WidgetProps {
 
 export const LicenseParameter: React.FunctionComponent<LicenseProps> = props => {
     const error = props.errors[props.parameter.name] != null;
+    const provider = getProviderField();
     const doOpen = useCallback(() => {
         dialogStore.addDialog(<LicenseBrowse
             opts={{
@@ -31,10 +32,9 @@ export const LicenseParameter: React.FunctionComponent<LicenseProps> = props => 
                         dialogStore.success();
                     },
                     show(res) {
-                        const errorMessage = checkProviderMismatch(res, "Licenses");
-                        if (errorMessage) return errorMessage;
                         return true;
                     },
+                    provider: provider ?? null
                 }
             }}
         />, noopCall, true, largeModalStyle);

--- a/frontend-web/webclient/app/Applications/Jobs/Widgets/NetworkIP.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Widgets/NetworkIP.tsx
@@ -8,7 +8,7 @@ import {compute} from "@/UCloud";
 import AppParameterValueNS = compute.AppParameterValueNS;
 import {callAPI, noopCall} from "@/Authentication/DataHook";
 import {NetworkIP} from "@/UCloud/NetworkIPApi";
-import {checkProviderMismatch} from "../Create";
+import {checkProviderMismatch, getProviderField} from "../Create";
 import {NetworkIPBrowse} from "@/Applications/NetworkIP/NetworkIPBrowse";
 import {ApplicationParameterNS} from "@/Applications/AppStoreApi";
 import {dialogStore} from "@/Dialog/DialogStore";
@@ -31,11 +31,10 @@ export const NetworkIPParameter: React.FunctionComponent<NetworkIPProps> = props
                         dialogStore.success();
                     },
                     show(res) {
-                        const errorMessage = checkProviderMismatch(res, "Public IPs");
-                        if (errorMessage) return errorMessage;
                         return res.status.boundTo.length === 0;
                     },
-                }
+                    provider: getProviderField() ?? null,
+                },
             }}
         />, noopCall, true, largeModalStyle);
     }, []);

--- a/frontend-web/webclient/app/Applications/Jobs/Widgets/Peer.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Widgets/Peer.tsx
@@ -7,7 +7,7 @@ import Input from "@/ui-components/Input";
 import Label from "@/ui-components/Label";
 import {default as ReactModal} from "react-modal";
 import {largeModalStyle} from "@/Utilities/ModalUtilities";
-import {checkProviderMismatch} from "../Create";
+import {checkProviderMismatch, getProviderField} from "../Create";
 import JobBrowse from "../JobsBrowse";
 import {CardClass} from "@/ui-components/Card";
 import {ApplicationParameter, ApplicationParameterNS} from "@/Applications/AppStoreApi";
@@ -138,11 +138,10 @@ const JobSelector: React.FunctionComponent<JobSelectorProps> = props => {
                     isModal: true,
                     selection: {
                         text: "Use",
-                        show(job) {
-                            const errorMessage = checkProviderMismatch(job, "Jobs");
-                            if (errorMessage) return errorMessage;
+                        show() {
                             return true;
                         },
+                        provider: getProviderField() ?? null,
                         onClick(job) {
                             const el = document.getElementById(widgetId(props.parameter) + "job");
                             if (el) {

--- a/frontend-web/webclient/app/Applications/OpenWith.tsx
+++ b/frontend-web/webclient/app/Applications/OpenWith.tsx
@@ -111,8 +111,17 @@ export function OpenWithBrowser({opts, file}: {file: UFile, opts?: ResourceBrows
                             }
                         },
                         show: () => true,
-                        text: "Launch"
-                    }, entry);
+                        text: "Launch",
+                        provider: null,
+                    }, {
+                        ...entry, specification: {
+                            product: {
+                                category: "",
+                                id: "",
+                                provider: ""
+                            }
+                        }
+                    });
                     if (button) {
                         row.stat3.replaceChildren(button);
                     }

--- a/frontend-web/webclient/app/Files/FavoriteSelect.tsx
+++ b/frontend-web/webclient/app/Files/FavoriteSelect.tsx
@@ -8,6 +8,7 @@ import FavoritesBrowse from "./FavoritesBrowse";
 import {Operation, ShortcutKey} from "@/ui-components/Operation";
 import {snackbarStore} from "@/Snackbar/SnackbarStore";
 import {ResourceBrowseCallbacks} from "@/UCloud/ResourceApi";
+import {getProviderField} from "@/Applications/Jobs/Create";
 
 
 
@@ -34,7 +35,8 @@ export function addFavoriteSelect(onSelect: (file: UFile) => void, isFileAllowed
         show(res) {
             if ("path" in res) return true;
             else return isFileAllowed(res);
-        }
+        },
+        provider: getProviderField() ?? null,
     }} />, () => void 0);
 }
 

--- a/frontend-web/webclient/app/Files/FavoritesBrowse.tsx
+++ b/frontend-web/webclient/app/Files/FavoritesBrowse.tsx
@@ -128,7 +128,7 @@ function FavoriteBrowse({selection, navigateToFolder}: {navigateToFolder: (path:
                     return renderFileIconFromProperties(ext4, isDirectory || isLikelyDirectory(filePath), fileInfo?.status.icon);
                 };
 
-                browser.on("renderRow", (fav, row, containerWidth) => {
+                browser.on("renderRow", (fav, row) => {
                     const fileInfo = sidebarFavoriteCache.fileInfoIfPresent(fav.path);
                     const [icon, setIcon] = ResourceBrowser.defaultIconRenderer();
                     renderFileIcon(fav.path).then(setIcon)
@@ -149,9 +149,11 @@ function FavoriteBrowse({selection, navigateToFolder}: {navigateToFolder: (path:
 
                     row.star.setAttribute("data-favorite", "true");
 
-                    const button = browser.defaultButtonRenderer(selection, fileInfo ?? fav);
-                    if (button) {
-                        row.stat3.append(button);
+                    if (fileInfo) {
+                        const button = (browser as unknown as ResourceBrowser<UFile>).defaultButtonRenderer(selection, fileInfo);
+                        if (button) {
+                            row.stat3.append(button);
+                        }
                     }
                 });
 

--- a/frontend-web/webclient/app/Files/Shares.tsx
+++ b/frontend-web/webclient/app/Files/Shares.tsx
@@ -484,7 +484,8 @@ export function IngoingSharesBrowse({opts}: {opts?: ResourceBrowserOpts<Share> &
                             show() {
                                 return true;
                             },
-                            text: "Accept"
+                            text: "Accept",
+                            provider: null,
                         }, share, {color: "successMain", width: "72px"})!);
                         group.appendChild(browser.defaultButtonRenderer({
                             onClick: async () => {
@@ -494,7 +495,8 @@ export function IngoingSharesBrowse({opts}: {opts?: ResourceBrowserOpts<Share> &
                             show() {
                                 return true;
                             },
-                            text: "Decline"
+                            text: "Decline",
+                            provider: null,
                         }, share, {color: "errorMain", width: "72px"})!);
                     } else {
                         const {state} = share.status;

--- a/frontend-web/webclient/app/Project/ProjectInviteBrowse.tsx
+++ b/frontend-web/webclient/app/Project/ProjectInviteBrowse.tsx
@@ -156,7 +156,8 @@ function ProviderBrowse({opts}: {opts?: ResourceBrowserOpts<ProjectInvite> & Set
                         show(res) {
                             return true
                         },
-                        text: "Accept"
+                        text: "Accept",
+                        provider: null
                     }, invite, {color: "successMain", width: "72px"})!);
                     group.appendChild(browser.defaultButtonRenderer({
                         onClick: async () => {
@@ -166,7 +167,8 @@ function ProviderBrowse({opts}: {opts?: ResourceBrowserOpts<ProjectInvite> & Set
                         show(res) {
                             return true
                         },
-                        text: "Decline"
+                        text: "Decline",
+                        provider: null
                     }, invite, {color: "errorMain", width: "72px"})!);
                 });
 

--- a/frontend-web/webclient/app/Syncthing/Legacy/Overview.tsx
+++ b/frontend-web/webclient/app/Syncthing/Legacy/Overview.tsx
@@ -389,6 +389,7 @@ export const Overview: React.FunctionComponent = () => {
                             dispatch({type: "AddFolder", folderPath: target});
                             dialogStore.success();
                         },
+                        provider,
                     }
                 }}
             />,

--- a/frontend-web/webclient/app/Syncthing/Overview.tsx
+++ b/frontend-web/webclient/app/Syncthing/Overview.tsx
@@ -276,7 +276,6 @@ const NewOverview: React.FunctionComponent = () => {
                         show(file) {
                             if (file.status.type !== "DIRECTORY") return false;
                             if (file.specification.product.id === "share") return false;
-                            if (file.specification.product.provider != provider) return false;
                             if (file.permissions.myself.indexOf("EDIT") === -1 && file.permissions.myself.indexOf("ADMIN") === -1) return false;
 
                             return true;
@@ -296,6 +295,7 @@ const NewOverview: React.FunctionComponent = () => {
                             dispatch({type: "AddFolder", folderPath: target});
                             dialogStore.success();
                         },
+                        provider,
                     }
                 }}
             />,
@@ -694,6 +694,7 @@ function SyncedFolders({folders, dispatch, opts}: {
                         },
                         show: () => true,
                         text: "",
+                        provider: null,
                     }, folder, {
                         color: "errorMain", width: "20px", button: {
                             name: "close", size: 18, color: "fixedWhite", color2: "fixedWhite", ml: "8px"
@@ -807,6 +808,7 @@ function DeviceBrowse({devices, dispatch, opts}: {
                         },
                         show: () => true,
                         text: "",
+                        provider: null
                     }, device, {
                         color: "errorMain", width: "20px", button: {
                             name: "close", size: 18, color: "fixedWhite", color2: "fixedWhite", ml: "8px"

--- a/frontend-web/webclient/app/UCloud/FilesApi.tsx
+++ b/frontend-web/webclient/app/UCloud/FilesApi.tsx
@@ -421,7 +421,8 @@ class FilesApi extends ResourceApi<UFile, ProductStorage, UFileSpecification,
                                     } catch (e) {
                                         displayErrorMessageOrDefault(e, "Failed to move to folder");
                                     }
-                                }
+                                },
+                                provider: null,
                             },
                             initialPath: pathRef.current,
                         }} />,
@@ -744,7 +745,7 @@ class FilesApi extends ResourceApi<UFile, ProductStorage, UFileSpecification,
         }
     }
 
-    public copyModal(ids: string[], provider: string, reload: (result: any) => void) {
+    public copyModal(ids: string[], provider: string, reload: (result) => void) {
         const pathRef = {current: getParentPath(ids[0])};
         dialogStore.addDialog(
             <FileBrowse opts={{
@@ -774,7 +775,8 @@ class FilesApi extends ResourceApi<UFile, ProductStorage, UFileSpecification,
                             displayErrorMessageOrDefault(e, "Failed to move to folder");
                             return false;
                         }
-                    }
+                    },
+                    provider
                 },
                 additionalFilters: {
                     filterProvider: provider
@@ -816,7 +818,8 @@ class FilesApi extends ResourceApi<UFile, ProductStorage, UFileSpecification,
                         } catch (e) {
                             displayErrorMessageOrDefault(e, "Failed to move to folder");
                         }
-                    }
+                    },
+                    provider
                 },
                 initialPath: pathRef.current,
                 additionalFilters: {filterProvider: provider}


### PR DESCRIPTION
The type is string | null, to ensure that it's always set intentionally.

License not tested (where do we have one?).
Public IPs not validated (permission denied on use).

Keeping it as a draft until licenses and public IPs are properly tested.