### PR TITLE
Fixes #5454

### DIFF
--- a/frontend-web/webclient/app/Authentication/lib.ts
+++ b/frontend-web/webclient/app/Authentication/lib.ts
@@ -1,5 +1,5 @@
 import {Store} from "redux";
-import {b64DecodeUnicode, inRange, inSuccessRange, is5xxStatusCode} from "@/UtilityFunctions";
+import {b64DecodeUnicode, displayErrorMessageOrDefault, inRange, inSuccessRange, is5xxStatusCode} from "@/UtilityFunctions";
 import {setStoredProject} from "@/Project/ReduxState";
 import {CallParameters} from "./CallParameters";
 import {signIntentToCall, clearSigningKey} from "@/Authentication/MessageSigning";
@@ -28,6 +28,8 @@ export function parseJWT(encodedJWT: string): JWT | null {
 
     return parsed;
 }
+
+let nextAllowedFailureNotificationTS = 0;
 
 /**
  * Represents an instance of the HTTPClient object used for contacting the backend, implicitly using JWTs.
@@ -215,8 +217,14 @@ export class HttpClient {
             });
         } catch (e) {
             console.warn(e);
-            if (!this.isPublicPage) sendFailureNotification("Could not refresh login token.");
-            if ([401, 403].includes(e.status)) HttpClient.clearTokens();
+            if (!this.isPublicPage) {
+                if (nextAllowedFailureNotificationTS < new Date().getTime()) {
+                    nextAllowedFailureNotificationTS = new Date().getTime() + 1_000;
+                    sendFailureNotification("Could not refresh login token.");
+                }
+            } else if ([401, 403].includes(e.status)) {
+                HttpClient.clearTokens();
+            }
         }
     }
 


### PR DESCRIPTION
Ensures that's there (usually) only one "Could not refresh login token."
<img width="495" height="281" alt="Screenshot 2026-03-16 at 16 06 03" src="https://github.com/user-attachments/assets/bb1bd9c7-ff7a-49e3-954e-054d50ab4494" />

This means the user will be presented with the other issues, relating to a `502` response that are not very informative, but I don't have a good solution to that issue right now.