### PR TITLE
Fix for unwanted home/projectMembers folders

### DIFF
--- a/core2/pkg/accounting/provider_notifications.go
+++ b/core2/pkg/accounting/provider_notifications.go
@@ -501,7 +501,9 @@ func providerNotificationHandleClient(conn *ws.Conn) {
 
 		case wallet, ok := <-walletUpdates:
 			if ok {
-				appendWallet(wallet)
+				if wallet.HasAllocations() {
+					appendWallet(wallet)
+				}
 			}
 
 		case project, ok := <-projectUpdates:

--- a/provider-integration/shared/pkg/accounting/accounting.go
+++ b/provider-integration/shared/pkg/accounting/accounting.go
@@ -26,6 +26,15 @@ type WalletV2 struct {
 	LastSignificantUpdateAt fnd.Timestamp `json:"lastSignificantUpdateAt"`
 }
 
+func (w *WalletV2) HasAllocations() bool {
+	for _, group := range w.AllocationGroups {
+		if len(group.Group.Allocations) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 type AllocationGroup struct {
 	Id          int          `json:"id"`
 	Allocations []Allocation `json:"allocations"`


### PR DESCRIPTION
Only send wallet updates when wallet has allocations.
Home folders for providers where user does not have resources is now not created.

Tested locally 