### PR TITLE
updated message to specify owner of resource for insufficient funds.

### DIFF
--- a/core2/pkg/accounting/provider_notifications.go
+++ b/core2/pkg/accounting/provider_notifications.go
@@ -469,6 +469,7 @@ func providerNotificationHandleClient(conn *ws.Conn) {
 			out.WriteU32(workspaceRef)
 			out.WriteU32(categoryRef)
 			out.WriteS64(wallet.Quota)
+			out.WriteS64(wallet.TotalUsage)
 			out.WriteU32(flags)
 			out.WriteS64(wallet.LastSignificantUpdateAt.UnixMilli())
 			if connFlags&0x1 != 0 {

--- a/provider-integration/im2/pkg/controller/event.go
+++ b/provider-integration/im2/pkg/controller/event.go
@@ -116,8 +116,8 @@ func eventHandleNotification(nType EventNotificationMessageType, notification an
 
 		allocationTrack(update)
 
-		log.Info("Handling wallet event %v %v %v %v %v", update.Owner.Username, update.Owner.ProjectId,
-			update.Category.Name, update.CombinedQuota, update.Locked)
+		log.Info("Handling wallet event %v %v %v %v %v %v", update.Owner.Username, update.Owner.ProjectId,
+			update.Category.Name, update.CombinedQuota, update.TotalUsage, update.Locked)
 
 		if LaunchUserInstances {
 			if update.Owner.Type == apm.WalletOwnerTypeUser {
@@ -265,6 +265,7 @@ func eventHandleSession(session *ws.Conn, userReplayChannel chan string, replayF
 					workspaceRef := readBuf.GetU32()
 					categoryRef := readBuf.GetU32()
 					combinedQuota := readBuf.GetU64()
+					totalUsage := readBuf.GetU64()
 					flags := readBuf.GetU32()
 					lastUpdate := readBuf.GetU64()
 					localRetiredUsage := readBuf.GetU64()
@@ -280,6 +281,7 @@ func eventHandleSession(session *ws.Conn, userReplayChannel chan string, replayF
 
 					notification := EventWalletUpdated{
 						CombinedQuota:     combinedQuota,
+						TotalUsage:        totalUsage,
 						LastUpdate:        fnd.TimeFromUnixMilli(lastUpdate),
 						Locked:            isLocked,
 						Category:          category,
@@ -368,6 +370,7 @@ type EventWalletUpdated struct {
 	Owner             apm.WalletOwner
 	Category          apm.ProductCategory
 	CombinedQuota     uint64
+	TotalUsage        uint64
 	Locked            bool
 	LastUpdate        fnd.Timestamp
 	Project           util.Option[fnd.Project]
@@ -657,6 +660,7 @@ type TrackedAllocation struct {
 	Owner             apm.WalletOwner
 	Category          string
 	CombinedQuota     uint64
+	TotalUsage        uint64
 	Locked            bool
 	LastUpdate        fnd.Timestamp
 	LocalRetiredUsage uint64
@@ -665,21 +669,22 @@ type TrackedAllocation struct {
 func allocationTrack(update *EventWalletUpdated) {
 	cacheKey := lockedCacheKey{Owner: update.Owner, Category: update.Category.Name}
 	isLockedCacheMutex.Lock()
-	isLockedCache[cacheKey] = update.Locked
+	isLockedCache[cacheKey] = ResourceLockInfo{util.OptStringIfNotEmpty(update.Owner.Username), util.OptStringIfNotEmpty(update.Owner.ProjectId), update.Locked, update.CombinedQuota, update.TotalUsage}
 	isLockedCacheMutex.Unlock()
 
 	db.NewTx0(func(tx *db.Transaction) {
 		db.Exec(
 			tx,
 			`
-				insert into tracked_allocations(owner_username, owner_project, category, combined_quota,
-					locked, last_update, local_retired_usage)
-				values (:owner_username, :owner_project, :category, :combined_quota, :locked, now(), :local_retired_usage)
+				insert into tracked_allocations(owner_username, owner_project, category, combined_quota, 
+					locked, last_update, local_retired_usage, total_usage)
+				values (:owner_username, :owner_project, :category, :combined_quota, :locked, now(), :local_retired_usage, :total_usage)
 				on conflict(category, owner_username, owner_project) do update set
 					combined_quota = excluded.combined_quota,
 					locked = excluded.locked,
 					last_update = excluded.last_update,
-					local_retired_usage = excluded.local_retired_usage
+					local_retired_usage = excluded.local_retired_usage,
+					total_usage = excluded.total_usage
 			`,
 			db.Params{
 				"owner_username":      update.Owner.Username,
@@ -688,6 +693,7 @@ func allocationTrack(update *EventWalletUpdated) {
 				"combined_quota":      update.CombinedQuota,
 				"locked":              update.Locked,
 				"local_retired_usage": update.LocalRetiredUsage,
+				"total_usage":         update.TotalUsage,
 			},
 		)
 	})
@@ -701,6 +707,7 @@ func AllocationsFindAll(categoryName string) []TrackedAllocation {
 			OwnerProject      string
 			Category          string
 			CombinedQuota     uint64
+			TotalUsage        uint64
 			LastUpdate        time.Time
 			Locked            bool
 			LocalRetiredUsage uint64
@@ -722,6 +729,7 @@ func AllocationsFindAll(categoryName string) []TrackedAllocation {
 				Owner:             apm.WalletOwnerFromIds(row.OwnerUsername, row.OwnerProject),
 				Category:          row.Category,
 				CombinedQuota:     row.CombinedQuota,
+				TotalUsage:        row.TotalUsage,
 				Locked:            row.Locked,
 				LastUpdate:        fnd.Timestamp(row.LastUpdate),
 				LocalRetiredUsage: row.LocalRetiredUsage,
@@ -737,12 +745,20 @@ type lockedCacheKey struct {
 	Category string
 }
 
-var isLockedCache = map[lockedCacheKey]bool{}
+type ResourceLockInfo struct {
+	Username      util.Option[string]
+	ProjectId     util.Option[string]
+	Locked        bool
+	CombinedQuota uint64
+	TotalUsage    uint64
+}
+
+var isLockedCache = map[lockedCacheKey]ResourceLockInfo{}
 var isLockedCacheMutex = sync.Mutex{}
 
-func WalletIsLocked(owner apm.WalletOwner, category string) bool {
+func WalletIsLocked(owner apm.WalletOwner, category string) ResourceLockInfo {
 	if category == "terminal" || category == "syncthing" {
-		return false // TODO(Dan): Fix this correctly.
+		return ResourceLockInfo{} // TODO(Dan): Fix this correctly.
 	}
 
 	if RunsServerCode() {
@@ -755,11 +771,17 @@ func WalletIsLocked(owner apm.WalletOwner, category string) bool {
 			return locked
 		}
 
-		locked = db.NewTx[bool](func(tx *db.Transaction) bool {
-			row, ok := db.Get[struct{ Locked bool }](
+		locked = db.NewTx[ResourceLockInfo](func(tx *db.Transaction) ResourceLockInfo {
+			row, ok := db.Get[struct {
+				OwnerUsername string
+				OwnerProject  string
+				Locked        bool
+				CombinedQuota uint64
+				TotalUsage    uint64
+			}](
 				tx,
 				`
-					select a.locked
+					select a.owner_username, a.owner_project, a.locked, a.combined_quota, a.total_usage
 					from tracked_allocations a
 					where
 						a.category = :category
@@ -774,9 +796,15 @@ func WalletIsLocked(owner apm.WalletOwner, category string) bool {
 			)
 
 			if !ok {
-				return false
+				return ResourceLockInfo{}
 			} else {
-				return row.Locked
+				return ResourceLockInfo{
+					Username:      util.OptStringIfNotEmpty(row.OwnerUsername),
+					ProjectId:     util.OptStringIfNotEmpty(row.OwnerProject),
+					Locked:        row.Locked,
+					CombinedQuota: row.CombinedQuota,
+					TotalUsage:    row.TotalUsage,
+				}
 			}
 		})
 
@@ -790,5 +818,16 @@ func WalletIsLocked(owner apm.WalletOwner, category string) bool {
 }
 
 func ResourceIsLocked(resource orc.Resource, ref apm.ProductReference) bool {
+	return WalletIsLocked(apm.WalletOwnerFromIds(resource.Owner.CreatedBy, resource.Owner.Project.Value), ref.Category).Locked
+}
+
+func RetrieveResourceLockInfo(resource orc.Resource, ref apm.ProductReference) ResourceLockInfo {
 	return WalletIsLocked(apm.WalletOwnerFromIds(resource.Owner.CreatedBy, resource.Owner.Project.Value), ref.Category)
+}
+
+func MakeInsufficientFundsMessage(lockInfo ResourceLockInfo, category string) string {
+	if lockInfo.TotalUsage >= lockInfo.CombinedQuota {
+		return fmt.Sprintf("This workspace has reached the %s quota.", category)
+	}
+	return fmt.Sprintf("This workspace cannot create %ss. Please contact your quota administrator. ", category)
 }

--- a/provider-integration/im2/pkg/controller/event.go
+++ b/provider-integration/im2/pkg/controller/event.go
@@ -829,5 +829,5 @@ func MakeInsufficientFundsMessage(lockInfo ResourceLockInfo, category string) st
 	if lockInfo.TotalUsage >= lockInfo.CombinedQuota {
 		return fmt.Sprintf("This workspace has reached the %s quota.", category)
 	}
-	return fmt.Sprintf("This workspace cannot create %ss. Please contact your quota administrator. ", category)
+	return fmt.Sprintf("This workspace cannot create %ss due to over allocation. Please contact your quota administrator. ", category)
 }

--- a/provider-integration/im2/pkg/controller/jobs.go
+++ b/provider-integration/im2/pkg/controller/jobs.go
@@ -2103,7 +2103,7 @@ func jobsMakeInsufficientFundsMessage(resource orcapi.Resource, category string)
 		projectId = project.Specification.Parent.Value
 		parentProject, ok := ProjectRetrieve(projectId)
 		if !ok {
-			log.Warn("Failed to retrieve parent project with id: %s", projectId)
+			log.Warn("Failed to retrieve parent project with id: %s", project.Specification.Parent.Value)
 			return fmt.Sprintf("This subproject %s of %s %s", project.Specification.Title, project.Specification.Parent.Value, reason)
 		}
 		return fmt.Sprintf("This subproject %s of %s %s", project.Specification.Title, parentProject.Specification.Title, reason)

--- a/provider-integration/im2/pkg/controller/jobs.go
+++ b/provider-integration/im2/pkg/controller/jobs.go
@@ -878,9 +878,11 @@ func initJobs() {
 			var errors []*util.HttpError
 			var providerIds []fnd.FindByStringId
 
+			lockInfo := ResourceLockInfo{}
 			for _, item := range request.Items {
-				if ResourceIsLocked(item.Resource, item.Specification.Product) {
-					return fnd.BulkResponse[fnd.FindByStringId]{}, util.HttpErr(http.StatusPaymentRequired, jobsMakeInsufficientFundsMessage(item.Resource, item.Specification.Product.Category))
+				lockInfo = RetrieveResourceLockInfo(item.Resource, item.Specification.Product)
+				if lockInfo.Locked {
+					return fnd.BulkResponse[fnd.FindByStringId]{}, util.HttpErr(http.StatusPaymentRequired, MakeInsufficientFundsMessage(lockInfo, item.Specification.Product.Category))
 				}
 			}
 
@@ -1136,9 +1138,11 @@ func initJobs() {
 			var errors []*util.HttpError
 			var providerIds []fnd.FindByStringId
 
+			lockInfo := ResourceLockInfo{}
 			for _, item := range request.Items {
+				lockInfo = RetrieveResourceLockInfo(item.Resource, item.Specification.Product)
 				if ResourceIsLocked(item.Resource, item.Specification.Product) {
-					return fnd.BulkResponse[fnd.FindByStringId]{}, util.HttpErr(http.StatusPaymentRequired, jobsMakeInsufficientFundsMessage(item.Resource, item.Specification.Product.Category))
+					return fnd.BulkResponse[fnd.FindByStringId]{}, util.HttpErr(http.StatusPaymentRequired, MakeInsufficientFundsMessage(lockInfo, item.Specification.Product.Category))
 				}
 			}
 
@@ -2085,28 +2089,21 @@ func jobRoutesRefresh() {
 	webSessionsMutex.Unlock()
 }
 
-func jobsMakeInsufficientFundsMessage(resource orcapi.Resource, category string) string {
-	reason := fmt.Sprintf("cannot create %s due to insufficient funds.", category)
-	if resource.Owner.Project.IsEmpty() {
-		return fmt.Sprintf("This user %s %s", resource.Owner.CreatedBy, reason)
+func jobsRetrieveOwner(lockInfo ResourceLockInfo) string {
+	if lockInfo.Username.IsEmpty() && lockInfo.ProjectId.IsEmpty() {
+		log.Warn("No owner is found")
+		return ""
 	}
-
-	projectId := resource.Owner.Project.Value
-	project, ok := ProjectRetrieve(projectId)
-
-	if !ok {
-		log.Warn("Failed to retrieve project with id: %s", projectId)
-		return fmt.Sprintf("This project %s %s ", projectId, reason)
+	if lockInfo.Username.Present {
+		return lockInfo.Username.Value
 	}
-	// If we have a parent, refer to it
-	if project.Specification.Parent.Present {
-		projectId = project.Specification.Parent.Value
-		parentProject, ok := ProjectRetrieve(projectId)
+	if lockInfo.ProjectId.Present {
+		project, ok := ProjectRetrieve(lockInfo.ProjectId.Value)
 		if !ok {
-			log.Warn("Failed to retrieve parent project with id: %s", project.Specification.Parent.Value)
-			return fmt.Sprintf("This subproject %s of %s %s", project.Specification.Title, project.Specification.Parent.Value, reason)
+			log.Warn("Project %s not found", lockInfo.ProjectId.Value)
+			return ""
 		}
-		return fmt.Sprintf("This subproject %s of %s %s", project.Specification.Title, parentProject.Specification.Title, reason)
+		return project.Specification.Title
 	}
-	return fmt.Sprintf("This project %s %s ", project.Specification.Title, reason)
+	return ""
 }

--- a/provider-integration/im2/pkg/controller/jobs.go
+++ b/provider-integration/im2/pkg/controller/jobs.go
@@ -2086,14 +2086,16 @@ func jobRoutesRefresh() {
 }
 
 func jobsMakeInsuffiecientFundsMessage(resource orcapi.Resource, category string) string {
-	owner := "The user " + resource.Owner.CreatedBy
-	if resource.Owner.Project.Present {
-		project, ok := ProjectRetrieve(resource.Owner.Project.Value)
-		if !ok {
-			owner = "The unknown owner"
-		} else {
-			owner = "The project " + project.Specification.Title
-		}
+	reason := fmt.Sprintf("cannot create %s due to insufficient funds.", category)
+	if resource.Owner.Project.IsEmpty() {
+		return fmt.Sprintf("The user %s %s", resource.Owner.CreatedBy, reason)
 	}
-	return fmt.Sprintf("%s cannot create %s due to insufficient funds.", owner, category)
+
+	projectId := resource.Owner.Project.Value
+	project, ok := ProjectRetrieve(projectId)
+	if !ok {
+		log.Warn("Failed to retrieve project with id: %s", projectId)
+		return fmt.Sprintf("The project %s %s ", projectId, reason)
+	}
+	return fmt.Sprintf("The project %s %s ", project.Specification.Title, reason)
 }

--- a/provider-integration/im2/pkg/controller/jobs.go
+++ b/provider-integration/im2/pkg/controller/jobs.go
@@ -880,7 +880,7 @@ func initJobs() {
 
 			for _, item := range request.Items {
 				if ResourceIsLocked(item.Resource, item.Specification.Product) {
-					return fnd.BulkResponse[fnd.FindByStringId]{}, util.HttpErr(http.StatusPaymentRequired, jobsMakeInsuffiecientFundsMessage(item.Resource, item.Specification.Product.Category))
+					return fnd.BulkResponse[fnd.FindByStringId]{}, util.HttpErr(http.StatusPaymentRequired, jobsMakeInsufficientFundsMessage(item.Resource, item.Specification.Product.Category))
 				}
 			}
 
@@ -1138,7 +1138,7 @@ func initJobs() {
 
 			for _, item := range request.Items {
 				if ResourceIsLocked(item.Resource, item.Specification.Product) {
-					return fnd.BulkResponse[fnd.FindByStringId]{}, util.HttpErr(http.StatusPaymentRequired, "insufficient funds for %s", item.Specification.Product.Category)
+					return fnd.BulkResponse[fnd.FindByStringId]{}, util.HttpErr(http.StatusPaymentRequired, jobsMakeInsufficientFundsMessage(item.Resource, item.Specification.Product.Category))
 				}
 			}
 
@@ -2085,7 +2085,7 @@ func jobRoutesRefresh() {
 	webSessionsMutex.Unlock()
 }
 
-func jobsMakeInsuffiecientFundsMessage(resource orcapi.Resource, category string) string {
+func jobsMakeInsufficientFundsMessage(resource orcapi.Resource, category string) string {
 	reason := fmt.Sprintf("cannot create %s due to insufficient funds.", category)
 	if resource.Owner.Project.IsEmpty() {
 		return fmt.Sprintf("The user %s %s", resource.Owner.CreatedBy, reason)
@@ -2093,9 +2093,20 @@ func jobsMakeInsuffiecientFundsMessage(resource orcapi.Resource, category string
 
 	projectId := resource.Owner.Project.Value
 	project, ok := ProjectRetrieve(projectId)
+
 	if !ok {
 		log.Warn("Failed to retrieve project with id: %s", projectId)
 		return fmt.Sprintf("The project %s %s ", projectId, reason)
 	}
-	return fmt.Sprintf("The project %s %s ", project.Specification.Title, reason)
+	// If we have a parent, refer to it
+	if project.Specification.Parent.Present {
+		projectId = project.Specification.Parent.Value
+		parentProject, ok := ProjectRetrieve(projectId)
+		if !ok {
+			log.Warn("Failed to retrieve parent project with id: %s", projectId)
+			return fmt.Sprintf("This subproject %s of %s %s", project.Specification.Title, project.Specification.Parent.Value, reason)
+		}
+		return fmt.Sprintf("This subproject %s of %s %s", project.Specification.Title, parentProject.Specification.Title, reason)
+	}
+	return fmt.Sprintf("This project %s %s ", project.Specification.Title, reason)
 }

--- a/provider-integration/im2/pkg/controller/jobs.go
+++ b/provider-integration/im2/pkg/controller/jobs.go
@@ -2088,7 +2088,7 @@ func jobRoutesRefresh() {
 func jobsMakeInsufficientFundsMessage(resource orcapi.Resource, category string) string {
 	reason := fmt.Sprintf("cannot create %s due to insufficient funds.", category)
 	if resource.Owner.Project.IsEmpty() {
-		return fmt.Sprintf("The user %s %s", resource.Owner.CreatedBy, reason)
+		return fmt.Sprintf("This user %s %s", resource.Owner.CreatedBy, reason)
 	}
 
 	projectId := resource.Owner.Project.Value
@@ -2096,7 +2096,7 @@ func jobsMakeInsufficientFundsMessage(resource orcapi.Resource, category string)
 
 	if !ok {
 		log.Warn("Failed to retrieve project with id: %s", projectId)
-		return fmt.Sprintf("The project %s %s ", projectId, reason)
+		return fmt.Sprintf("This project %s %s ", projectId, reason)
 	}
 	// If we have a parent, refer to it
 	if project.Specification.Parent.Present {

--- a/provider-integration/im2/pkg/controller/jobs.go
+++ b/provider-integration/im2/pkg/controller/jobs.go
@@ -2088,22 +2088,3 @@ func jobRoutesRefresh() {
 
 	webSessionsMutex.Unlock()
 }
-
-func jobsRetrieveOwner(lockInfo ResourceLockInfo) string {
-	if lockInfo.Username.IsEmpty() && lockInfo.ProjectId.IsEmpty() {
-		log.Warn("No owner is found")
-		return ""
-	}
-	if lockInfo.Username.Present {
-		return lockInfo.Username.Value
-	}
-	if lockInfo.ProjectId.Present {
-		project, ok := ProjectRetrieve(lockInfo.ProjectId.Value)
-		if !ok {
-			log.Warn("Project %s not found", lockInfo.ProjectId.Value)
-			return ""
-		}
-		return project.Specification.Title
-	}
-	return ""
-}

--- a/provider-integration/im2/pkg/controller/jobs.go
+++ b/provider-integration/im2/pkg/controller/jobs.go
@@ -880,7 +880,7 @@ func initJobs() {
 
 			for _, item := range request.Items {
 				if ResourceIsLocked(item.Resource, item.Specification.Product) {
-					return fnd.BulkResponse[fnd.FindByStringId]{}, util.HttpErr(http.StatusPaymentRequired, "insufficient funds for %s", item.Specification.Product.Category)
+					return fnd.BulkResponse[fnd.FindByStringId]{}, util.HttpErr(http.StatusPaymentRequired, jobsMakeInsuffiecientFundsMessage(item.Resource, item.Specification.Product.Category))
 				}
 			}
 
@@ -2083,4 +2083,17 @@ func jobRoutesRefresh() {
 	}
 
 	webSessionsMutex.Unlock()
+}
+
+func jobsMakeInsuffiecientFundsMessage(resource orcapi.Resource, category string) string {
+	owner := "The user " + resource.Owner.CreatedBy
+	if resource.Owner.Project.Present {
+		project, ok := ProjectRetrieve(resource.Owner.Project.Value)
+		if !ok {
+			owner = "The unknown owner"
+		} else {
+			owner = "The project " + project.Specification.Title
+		}
+	}
+	return fmt.Sprintf("%s cannot create %s due to insufficient funds.", owner, category)
 }

--- a/provider-integration/im2/pkg/integrations/k8s/00_module.go
+++ b/provider-integration/im2/pkg/integrations/k8s/00_module.go
@@ -114,7 +114,7 @@ func IsJobLockedEx(job *orc.Job, jobAnnotations map[string]string) util.Option[s
 	metricComputeLocked.Observe(timer.Mark().Seconds())
 
 	if isLocked {
-		reason := fmt.Sprintf("Insufficient funds for %v", job.Specification.Product.Category)
+		reason := makeInsufficientFundsMessage(job.Resource, job.Specification.Product.Category)
 		return util.OptValue(shared.LockedReason{
 			Reason: reason,
 			Err: &util.HttpError{
@@ -161,7 +161,7 @@ func IsJobLockedEx(job *orc.Job, jobAnnotations map[string]string) util.Option[s
 		metricStorageLocked.Observe(timer.Mark().Seconds())
 
 		if storageLocked {
-			reason := fmt.Sprintf("Insufficient funds for %v", mount.RealDrive.Specification.Product.Category)
+			reason := makeInsufficientFundsMessage(mount.RealDrive.Resource, mount.RealDrive.Specification.Product.Category)
 			return util.OptValue(shared.LockedReason{
 				Reason: reason,
 				Err: &util.HttpError{
@@ -398,3 +398,16 @@ var metricMountedDrivesTiming = promauto.NewSummaryVec(prometheus.SummaryOpts{
 		0.99: 0.01,
 	},
 }, []string{"region"})
+
+func makeInsufficientFundsMessage(resource orc.Resource, category string) string {
+	owner := "The user " + resource.Owner.CreatedBy
+	if resource.Owner.Project.Present {
+		project, ok := controller.ProjectRetrieve(resource.Owner.Project.Value)
+		if !ok {
+			owner = "The unknown owner"
+		} else {
+			owner = "The project " + project.Specification.Title
+		}
+	}
+	return fmt.Sprintf("%s cannot create %s due to insufficient funds.", owner, category)
+}

--- a/provider-integration/im2/pkg/integrations/k8s/00_module.go
+++ b/provider-integration/im2/pkg/integrations/k8s/00_module.go
@@ -403,7 +403,7 @@ var metricMountedDrivesTiming = promauto.NewSummaryVec(prometheus.SummaryOpts{
 func makeInsufficientFundsMessage(resource orc.Resource, category string) string {
 	reason := fmt.Sprintf("cannot create %s due to insufficient funds.", category)
 	if resource.Owner.Project.IsEmpty() {
-		return fmt.Sprintf("The user %s %s", resource.Owner.CreatedBy, reason)
+		return fmt.Sprintf("This user %s %s", resource.Owner.CreatedBy, reason)
 	}
 
 	projectId := resource.Owner.Project.Value
@@ -411,7 +411,7 @@ func makeInsufficientFundsMessage(resource orc.Resource, category string) string
 
 	if !ok {
 		log.Warn("Failed to retrieve project with id: %s", projectId)
-		return fmt.Sprintf("The project %s %s ", projectId, reason)
+		return fmt.Sprintf("This project %s %s ", projectId, reason)
 	}
 	// If we have a parent, refer to it
 	if project.Specification.Parent.Present {

--- a/provider-integration/im2/pkg/integrations/k8s/00_module.go
+++ b/provider-integration/im2/pkg/integrations/k8s/00_module.go
@@ -12,6 +12,7 @@ import (
 	"ucloud.dk/pkg/integrations/k8s/containers"
 	"ucloud.dk/pkg/integrations/k8s/filesystem"
 	"ucloud.dk/pkg/integrations/k8s/shared"
+	"ucloud.dk/shared/pkg/log"
 	orc "ucloud.dk/shared/pkg/orchestrators"
 
 	"ucloud.dk/shared/pkg/util"
@@ -400,14 +401,16 @@ var metricMountedDrivesTiming = promauto.NewSummaryVec(prometheus.SummaryOpts{
 }, []string{"region"})
 
 func makeInsufficientFundsMessage(resource orc.Resource, category string) string {
-	owner := "The user " + resource.Owner.CreatedBy
-	if resource.Owner.Project.Present {
-		project, ok := controller.ProjectRetrieve(resource.Owner.Project.Value)
-		if !ok {
-			owner = "The unknown owner"
-		} else {
-			owner = "The project " + project.Specification.Title
-		}
+	reason := fmt.Sprintf("cannot create %s due to insufficient funds.", category)
+	if resource.Owner.Project.IsEmpty() {
+		return fmt.Sprintf("The user %s %s", resource.Owner.CreatedBy, reason)
 	}
-	return fmt.Sprintf("%s cannot create %s due to insufficient funds.", owner, category)
+
+	projectId := resource.Owner.Project.Value
+	project, ok := controller.ProjectRetrieve(projectId)
+	if !ok {
+		log.Warn("Failed to retrieve project with id: %s", projectId)
+		return fmt.Sprintf("The project %s %s ", projectId, reason)
+	}
+	return fmt.Sprintf("The project %s %s ", project.Specification.Title, reason)
 }

--- a/provider-integration/im2/pkg/integrations/k8s/00_module.go
+++ b/provider-integration/im2/pkg/integrations/k8s/00_module.go
@@ -12,7 +12,6 @@ import (
 	"ucloud.dk/pkg/integrations/k8s/containers"
 	"ucloud.dk/pkg/integrations/k8s/filesystem"
 	"ucloud.dk/pkg/integrations/k8s/shared"
-	"ucloud.dk/shared/pkg/log"
 	orc "ucloud.dk/shared/pkg/orchestrators"
 
 	"ucloud.dk/shared/pkg/util"
@@ -111,11 +110,11 @@ func IsJobLocked(job *orc.Job) util.Option[shared.LockedReason] {
 
 func IsJobLockedEx(job *orc.Job, jobAnnotations map[string]string) util.Option[shared.LockedReason] {
 	timer := util.NewTimer()
-	isLocked := controller.ResourceIsLocked(job.Resource, job.Specification.Product)
+	lockInfo := controller.RetrieveResourceLockInfo(job.Resource, job.Specification.Product)
 	metricComputeLocked.Observe(timer.Mark().Seconds())
 
-	if isLocked {
-		reason := makeInsufficientFundsMessage(job.Resource, job.Specification.Product.Category)
+	if lockInfo.Locked {
+		reason := controller.MakeInsufficientFundsMessage(lockInfo, job.Specification.Product.Category)
 		return util.OptValue(shared.LockedReason{
 			Reason: reason,
 			Err: &util.HttpError{
@@ -158,11 +157,12 @@ func IsJobLockedEx(job *orc.Job, jobAnnotations map[string]string) util.Option[s
 		}
 
 		timer.Mark()
-		storageLocked := controller.ResourceIsLocked(mount.RealDrive.Resource, mount.RealDrive.Specification.Product)
+		lockInfo := controller.RetrieveResourceLockInfo(mount.RealDrive.Resource, mount.RealDrive.Specification.Product)
+
 		metricStorageLocked.Observe(timer.Mark().Seconds())
 
-		if storageLocked {
-			reason := makeInsufficientFundsMessage(mount.RealDrive.Resource, mount.RealDrive.Specification.Product.Category)
+		if lockInfo.Locked {
+			reason := controller.MakeInsufficientFundsMessage(lockInfo, mount.RealDrive.Specification.Product.Category)
 			return util.OptValue(shared.LockedReason{
 				Reason: reason,
 				Err: &util.HttpError{
@@ -399,29 +399,3 @@ var metricMountedDrivesTiming = promauto.NewSummaryVec(prometheus.SummaryOpts{
 		0.99: 0.01,
 	},
 }, []string{"region"})
-
-func makeInsufficientFundsMessage(resource orc.Resource, category string) string {
-	reason := fmt.Sprintf("cannot create %s due to insufficient funds.", category)
-	if resource.Owner.Project.IsEmpty() {
-		return fmt.Sprintf("This user %s %s", resource.Owner.CreatedBy, reason)
-	}
-
-	projectId := resource.Owner.Project.Value
-	project, ok := controller.ProjectRetrieve(projectId)
-
-	if !ok {
-		log.Warn("Failed to retrieve project with id: %s", projectId)
-		return fmt.Sprintf("This project %s %s ", projectId, reason)
-	}
-	// If we have a parent, refer to it
-	if project.Specification.Parent.Present {
-		projectId = project.Specification.Parent.Value
-		parentProject, ok := controller.ProjectRetrieve(projectId)
-		if !ok {
-			log.Warn("Failed to retrieve parent project with id: %s", project.Specification.Parent.Value)
-			return fmt.Sprintf("This subproject %s of %s %s", project.Specification.Title, project.Specification.Parent.Value, reason)
-		}
-		return fmt.Sprintf("This subproject %s of %s %s", project.Specification.Title, parentProject.Specification.Title, reason)
-	}
-	return fmt.Sprintf("This project %s %s ", project.Specification.Title, reason)
-}

--- a/provider-integration/im2/pkg/integrations/k8s/00_module.go
+++ b/provider-integration/im2/pkg/integrations/k8s/00_module.go
@@ -418,7 +418,7 @@ func makeInsufficientFundsMessage(resource orc.Resource, category string) string
 		projectId = project.Specification.Parent.Value
 		parentProject, ok := controller.ProjectRetrieve(projectId)
 		if !ok {
-			log.Warn("Failed to retrieve parent project with id: %s", projectId)
+			log.Warn("Failed to retrieve parent project with id: %s", project.Specification.Parent.Value)
 			return fmt.Sprintf("This subproject %s of %s %s", project.Specification.Title, project.Specification.Parent.Value, reason)
 		}
 		return fmt.Sprintf("This subproject %s of %s %s", project.Specification.Title, parentProject.Specification.Title, reason)

--- a/provider-integration/im2/pkg/integrations/k8s/00_module.go
+++ b/provider-integration/im2/pkg/integrations/k8s/00_module.go
@@ -408,9 +408,20 @@ func makeInsufficientFundsMessage(resource orc.Resource, category string) string
 
 	projectId := resource.Owner.Project.Value
 	project, ok := controller.ProjectRetrieve(projectId)
+
 	if !ok {
 		log.Warn("Failed to retrieve project with id: %s", projectId)
 		return fmt.Sprintf("The project %s %s ", projectId, reason)
 	}
-	return fmt.Sprintf("The project %s %s ", project.Specification.Title, reason)
+	// If we have a parent, refer to it
+	if project.Specification.Parent.Present {
+		projectId = project.Specification.Parent.Value
+		parentProject, ok := controller.ProjectRetrieve(projectId)
+		if !ok {
+			log.Warn("Failed to retrieve parent project with id: %s", projectId)
+			return fmt.Sprintf("This subproject %s of %s %s", project.Specification.Title, project.Specification.Parent.Value, reason)
+		}
+		return fmt.Sprintf("This subproject %s of %s %s", project.Specification.Title, parentProject.Specification.Title, reason)
+	}
+	return fmt.Sprintf("This project %s %s ", project.Specification.Title, reason)
 }

--- a/provider-integration/im2/pkg/integrations/k8s/inference.go
+++ b/provider-integration/im2/pkg/integrations/k8s/inference.go
@@ -465,7 +465,7 @@ func inferenceReportUsage(owner apm.WalletOwner, promptTokens int, completionTok
 }
 
 func inferenceIsLocked(owner apm.WalletOwner) bool {
-	return controller.WalletIsLocked(owner, inferenceGlobals.Product.Category.Name)
+	return controller.WalletIsLocked(owner, inferenceGlobals.Product.Category.Name).Locked
 }
 
 // API tokens
@@ -529,7 +529,7 @@ func inferenceApiKeyValidate(key string) (apm.WalletOwner, *util.HttpError) {
 	inferenceTokenIdToKey.Set(tokenId, key)
 
 	owner := apm.WalletOwnerFromReference(ownerRef)
-	if controller.WalletIsLocked(owner, inferenceGlobals.Product.Category.Name) {
+	if controller.WalletIsLocked(owner, inferenceGlobals.Product.Category.Name).Locked {
 		return apm.WalletOwner{}, util.HttpErr(http.StatusPaymentRequired, "no more resources available")
 	} else {
 		return owner, nil

--- a/provider-integration/im2/pkg/migrations/00_migrations.go
+++ b/provider-integration/im2/pkg/migrations/00_migrations.go
@@ -37,5 +37,5 @@ func Init() {
 	db.AddMigration(privateNetworkDatabaseV1())
 	db.AddMigration(k8sV2())
 	db.AddMigration(inferenceV2())
-	db.AddMigration(ampEventsV3())
+	db.AddMigration(apmEventsV3())
 }

--- a/provider-integration/im2/pkg/migrations/00_migrations.go
+++ b/provider-integration/im2/pkg/migrations/00_migrations.go
@@ -37,4 +37,5 @@ func Init() {
 	db.AddMigration(privateNetworkDatabaseV1())
 	db.AddMigration(k8sV2())
 	db.AddMigration(inferenceV2())
+	db.AddMigration(ampEventsV3())
 }

--- a/provider-integration/im2/pkg/migrations/apm_events.go
+++ b/provider-integration/im2/pkg/migrations/apm_events.go
@@ -64,3 +64,18 @@ func apmEventsV2() db.MigrationScript {
 		},
 	}
 }
+
+func ampEventsV3() db.MigrationScript {
+	return db.MigrationScript{
+		Id: "apmEventsV3",
+		Execute: func(tx *db.Transaction) {
+			db.Exec(
+				tx,
+				`
+					alter table tracked_allocations add column total_usage int8 not null default 0
+			    `,
+				db.Params{},
+			)
+		},
+	}
+}

--- a/provider-integration/im2/pkg/migrations/apm_events.go
+++ b/provider-integration/im2/pkg/migrations/apm_events.go
@@ -65,7 +65,7 @@ func apmEventsV2() db.MigrationScript {
 	}
 }
 
-func ampEventsV3() db.MigrationScript {
+func apmEventsV3() db.MigrationScript {
 	return db.MigrationScript{
 		Id: "apmEventsV3",
 		Execute: func(tx *db.Transaction) {


### PR DESCRIPTION
After some discussion we ended up having logic for indentifying if quota is used up, when resource is locked and the `total_usage` is greater or equal to the `combined_quota`, then this message will be shown :

`This workspace has reached the public-ip quota.`

In the case where some upstream project is preventing the creation, this happens when resource is locked and `total_usage` is below `combined_quota`, then this message will be shown:

`This workspace cannot create public-ips. Please contact your quota administrator.`

