### PR TITLE
Cache now deletes when resources with provider generated ids are deleted

### DIFF
--- a/core2/pkg/orchestrator/resources.go
+++ b/core2/pkg/orchestrator/resources.go
@@ -880,6 +880,12 @@ func ResourceUpdate[T any](
 
 			if resc.MarkedForDeletion {
 				delete(b.Resources, id)
+				if resc.ProviderId.Present {
+					providerBucket := resourceGetProvider(resc.BaseSpec.Product.Provider)
+					providerBucket.Mu.Lock()
+					delete(providerBucket.ProviderIds, resc.ProviderId.Value)
+					providerBucket.Mu.Unlock()
+				}
 			}
 		}
 


### PR DESCRIPTION
Was a caching error. Restart no longer required when delete happens. Fixes #5580