### PR TITLE
Fixes #5561

### DIFF
--- a/frontend-web/webclient/app/Applications/Jobs/Widgets/index.tsx
+++ b/frontend-web/webclient/app/Applications/Jobs/Widgets/index.tsx
@@ -194,24 +194,21 @@ export const Widget: React.FunctionComponent<WidgetProps & RootWidgetProps> = pr
 
     if (props.active !== false) {
         return <Box data-param-type={props.parameter.type} data-component={`app-parameter`}>
-            <Label htmlFor={`app-param-${parameter.name}`} style={{display: "block"}}>
+            <Box>
                 <Flex>
                     <Flex data-component={"param-title"}>
-                        {parameter.title}
+                        <WidgetLabel parameter={props.parameter} />
                         {parameter.optional ? null : <MandatoryField />}
                     </Flex>
                     {!parameter.optional || !props.onRemove ? null : (
-                        <>
-                            <Box ml="auto" />
-                            <Text color="errorMain" cursor="pointer" mb="4px" onClick={props.onRemove} selectable={false}
-                                data-component={"param-remove"} zIndex={1000}>
-                                Remove
-                                <Icon ml="6px" size={16} name="close" />
-                            </Text>
-                        </>
+                        <Text ml="auto" color="errorMain" cursor="pointer" mb="4px" onClick={props.onRemove} selectable={false}
+                            data-component={"param-remove"} zIndex={1000}>
+                            Remove
+                            <Icon ml="6px" size={16} name="close" />
+                        </Text>
                     )}
                 </Flex>
-            </Label>
+            </Box>
             {body}
             {error ? <TextP color={"errorMain"}>{error}</TextP> : null}
             <div className={MarkdownWrapper}>
@@ -256,6 +253,27 @@ const OptionalWidgetSearchWrapper = injectStyleSimple("optional-widget-search", 
     padding-bottom: 8px;
     overflow-y: auto;
 `);
+
+const DefaultParameterTitle: Record<string, string> = {
+    "input_file": "File name",
+    "input_directory": "Folder name",
+    "ingress": "Public link",
+    "network_ip": "Public IP",
+    "private_network": "Private network"
+};
+
+function WidgetLabel(props: {parameter: ApplicationParameter}): React.ReactNode {
+    switch (props.parameter.type) {
+        case "ingress":
+        case "input_directory":
+        case "input_file":
+        case "network_ip":
+        case "private_network":
+            const title = props.parameter.title ? props.parameter.title : DefaultParameterTitle[props.parameter.type];
+            return <Label htmlFor={widgetId(props.parameter) + "visual"}> {title}</Label >
+    }
+    return <Label htmlFor={widgetId(props.parameter)}>{props.parameter.title}</Label>
+}
 
 export function findElement<HTMLElement = HTMLInputElement>(param: {name: string}): HTMLElement | null {
     return document.getElementById(widgetId(param)) as HTMLElement | null;

--- a/frontend-web/webclient/app/Applications/PrivateNetwork/PrivateNetworkBrowse.tsx
+++ b/frontend-web/webclient/app/Applications/PrivateNetwork/PrivateNetworkBrowse.tsx
@@ -80,7 +80,7 @@ export function PrivateNetworkBrowse({
     const browserRef = React.useRef<ResourceBrowser<PrivateNetwork> | null>(null);
     const dispatch = useDispatch();
     const navigate = useNavigate();
-    usePage("Private networks", SidebarTabId.RESOURCES);
+    if (!opts?.isModal) usePage("Private networks", SidebarTabId.RESOURCES);
     const [switcher, setSwitcherWorkaround] = React.useState<React.ReactNode>(<></>);
 
     React.useEffect(() => {

--- a/frontend-web/webclient/package-lock.json
+++ b/frontend-web/webclient/package-lock.json
@@ -120,7 +120,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -370,6 +369,31 @@
             "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
             "license": "Apache-2.0"
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -377,6 +401,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -1091,7 +1116,6 @@
         "node_modules/@svgr/core": {
             "version": "8.1.0",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -1513,7 +1537,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
             "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -1839,7 +1862,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2273,7 +2295,6 @@
         "node_modules/cytoscape": {
             "version": "3.33.1",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -2613,7 +2634,6 @@
         "node_modules/d3-selection": {
             "version": "3.0.0",
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -6554,7 +6574,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
             "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6585,7 +6604,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
             "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -6750,7 +6768,6 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
             "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
                 "use-sync-external-store": "^1.4.0"
@@ -6899,8 +6916,7 @@
         },
         "node_modules/redux": {
             "version": "5.0.1",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/redux-thunk": {
             "version": "3.1.0",
@@ -7710,7 +7726,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -7745,7 +7760,6 @@
             "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "devOptional": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7998,7 +8012,6 @@
             "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
@@ -8121,7 +8134,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
             "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },


### PR DESCRIPTION
Adds default text for widgets where `title` is empty 

Makes labels clickable for Widgets with `visual` input fields, that previously didn't do anything (input_file, input_directory, ingress, network_ip, private_network)

Also fixes #5642

Note: some warnings have been hidden to make a smaller screenshot.

Before:
<img width="1290" height="874" alt="Screenshot 2026-07-02 at 10 10 44" src="https://github.com/user-attachments/assets/3c1c79f1-7c29-4d12-ab2b-e10cf186ff8d" />

After: 
<img width="1288" height="876" alt="Screenshot 2026-07-02 at 10 10 48" src="https://github.com/user-attachments/assets/443bb114-cf51-4228-936a-169b215e6043" />

Before:
<img width="1285" height="169" alt="Screenshot 2026-07-02 at 10 31 46" src="https://github.com/user-attachments/assets/ff7d6ec3-2f3f-40b9-b5e4-3b4290742f63" />

After: 
<img width="1295" height="187" alt="Screenshot 2026-07-02 at 10 30 40" src="https://github.com/user-attachments/assets/34016859-0c08-4c88-8dfc-a697448608ed" />
