### PR TITLE
A bunch of selector fixes

### DIFF
--- a/frontend-web/webclient/app/Products/Selector.tsx
+++ b/frontend-web/webclient/app/Products/Selector.tsx
@@ -370,7 +370,7 @@ export const ProductSelector: React.FunctionComponent<{
             </Box> : null}
             <Box width={isCompute ? "50%" : "100%"}>
                 {isCompute ? <Box>Machine type <MandatoryField /></Box> : null}
-                <div onClick={onToggle} className={InputClass} style={{display: "flex", height: "33.5px"}} ref={boxRef}>
+                <div onClick={onToggle} className={InputClass} style={{display: "flex", height: "33.5px", cursor: "pointer"}} ref={boxRef}>
                     {selected ?
                         <Flex alignItems={"center"} gap="8px">
                             {isCompute ? <Icon size={24} ml="-4px" name={selectedComputeCategory?.kind === "CPU" ? "heroCpuChip" : "gpu"} /> : <ProviderLogo providerId={selected?.category?.provider ?? "?"} size={24} />}
@@ -390,12 +390,12 @@ export const ProductSelector: React.FunctionComponent<{
         </Flex>
 
         {isCompute && selected ? <>
-            <div className={classConcat(SelectorBoxClass, props.slim === true ? "slim" : undefined)} onClick={onToggle} style={{marginTop: "10px"}}>
+            <div className={classConcat(SelectorBoxClass, props.slim === true ? "slim" : undefined)} style={{marginTop: "10px"}}>
                 <div className="selected">
                     <>
                         {props.slim !== true ?
                             <>
-                                <Flex ml="2px" mt="4px" justifyContent={"space-between"}>
+                                <Flex mt="4px" justifyContent={"space-between"}>
                                     <Flex>{selected?.name}</Flex>
                                     <Box px="8px" py="4px" backgroundColor={`var(--${queueStatusInfo.color})`} color="fixedWhite" borderRadius={"12px"}>{queueStatusInfo.message}</Box>
                                 </Flex>
@@ -606,7 +606,7 @@ const ProductName: React.FunctionComponent<{product: ProductV2}> = ({product}) =
 
 function ProductDescription({serviceProvider, category}: {serviceProvider: string; category: string;}): React.ReactNode {
     const description = useProductDescription(serviceProvider, category);
-    return <Text fontSize={14}>{description}</Text>;
+    return <Text color="textSecondary" fontSize={14}>{description}</Text>;
 }
 
 function useProductDescription(serviceProvider: string, category: string): string {
@@ -725,16 +725,16 @@ const ProductStats: React.FunctionComponent<{product: ProductV2}> = ({product}) 
         case "compute":
             const gpus = computeProduct.gpu ?? 0;
             const gpuType = computeProduct.fraction?.denominator !== 1 ? stupidPluralize(gpus, "MIG") : stupidPluralize(gpus, "GPU");
+            const width = gpus ? "25%" : "33%";
 
             return <>
-                <TableCell>{computeProduct.cpu} {stupidPluralize(computeProduct.cpu ?? 1, "vCPU")}<HardwareModel model={computeProduct.cpuModel} /></TableCell>
-                <TableCell>{computeProduct.memoryInGigs} GB RAM<HardwareModel model={computeProduct.memoryModel} /></TableCell>
-                <TableCell>
-                    {computeProduct.gpu === 0 || computeProduct.gpu == null ?
-                        null :
+                <TableCell width={width}>{computeProduct.cpu} {stupidPluralize(computeProduct.cpu ?? 1, "vCPU")}<HardwareModel model={computeProduct.cpuModel} /></TableCell>
+                <TableCell width={width}>{computeProduct.memoryInGigs} GB RAM<HardwareModel model={computeProduct.memoryModel} /></TableCell>
+                {computeProduct.gpu === 0 || computeProduct.gpu == null ?
+                    null : <TableCell width={width}>
                         <>{" "}{computeProduct.gpu} {gpuType} <HardwareModel model={computeProduct.gpuModel} /></>
-                    }
-                </TableCell>
+                    </TableCell>
+                }
             </>
         default:
             return <></>
@@ -771,11 +771,11 @@ function MachineTypeSelectionSlider(props: {
         <Flex mb="8px">
             <Box ml="4px"><ProductTypeKind category={props.selectedCategory.kind} isFractional={dividerIndex > 0} /></Box>
             {dividerIndex > 0 ? <>
-                <Box style={{position: "absolute", width: "1px", left: `calc(100% * ${dividerIndex / productCount})`, height: "34px", border: "1px solid var(--primaryMain)", borderTopLeftRadius: "12px", borderTopRightRadius: "12px", backgroundColor: "var(--primaryMain)"}}></Box>
+                <Box style={{position: "absolute", width: "6px", left: `calc(100% * ${dividerIndex / productCount})`, height: "33px", border: "1px solid var(--borderColor)", borderTopLeftRadius: "12px", borderTopRightRadius: "12px", backgroundColor: "var(--secondaryMain)", borderBottom: "0px"}}></Box>
                 <Box style={{position: "absolute", left: `calc(100% * ${dividerIndex / productCount} + 20px)`}} ml="4px"><ProductTypeKind category={props.selectedCategory.kind} /></Box>
             </> : null}
         </Flex>
-        <RangeInput value={props.idx} autoFocus onChange={e => props.onSelect(e.target.valueAsNumber)} min={0} max={props.selectedCategory.products.length - 1} markers={
+        <RangeInput value={props.idx} autoFocus onChange={props.onSelect} min={0} max={props.selectedCategory.products.length - 1} markers={
             props.selectedCategory.products.map(p => computeV2ComponentCount(p))}
         />
     </Box>
@@ -810,7 +810,6 @@ function computeV2ComponentCount(c: ProductV2Compute): string {
 export const SelectorBoxClass = injectStyle("selector-box", k => `
     ${k} {
         position: relative;
-        cursor: pointer;
         border-radius: 5px;
         border: 1px solid var(--borderColor, #f00);
         width: 100%;
@@ -837,7 +836,6 @@ export const SelectorBoxClass = injectStyle("selector-box", k => `
     }
 
     ${k} .selected {
-        cursor: pointer;
         padding: 7px 12px;
         line-height: 18px;
     }

--- a/frontend-web/webclient/app/ui-components/RangeInput.tsx
+++ b/frontend-web/webclient/app/ui-components/RangeInput.tsx
@@ -5,7 +5,7 @@ import Flex from "./Flex";
 interface RangeInputProps {
     value: number;
     autoFocus?: boolean;
-    onChange: React.ChangeEventHandler<HTMLInputElement, HTMLInputElement>;
+    onChange: (value: number) => void;
     min?: number;
     max: number;
     background?: string | undefined;
@@ -34,6 +34,7 @@ const MarkerWrapperStyle = injectStyle("thingy-style", cl => `
     ${cl} > .marker-text {
         text-align: center;
         width: 20px;
+        cursor: pointer;
         min-height: 20px;
         transform: rotate(0.75turn);
     }
@@ -47,8 +48,8 @@ function MarkerWrapper(props: React.PropsWithChildren): React.ReactNode {
 
 export default function RangeInput(props: RangeInputProps): React.ReactNode {
     const style: Record<string, string> = {
-        "--trackBackground": props.background ?? "var(--primaryMain)",
-        "--thumbColor": props.thumbColor ?? "var(--primaryMain)",
+        "--trackBackground": props.background ?? "var(--secondaryMain)",
+        "--thumbColor": props.thumbColor ?? "var(--primaryLight)",
     };
 
     const markers = React.useMemo(() => {
@@ -56,20 +57,28 @@ export default function RangeInput(props: RangeInputProps): React.ReactNode {
         return <>
             <MarkerWrapper>
                 {props.markers.map((_, idx) =>
-                    <Flex key={idx} width="20px" alignItems="center">
+                    <Flex key={idx} width="20px" cursor="pointer" alignItems="center" onClick={() => {
+                        props.onChange(idx);
+                    }}>
                         <div className="marker-mark" />
                     </Flex>
                 )}
             </MarkerWrapper>
             <MarkerWrapper>
-                {props.markers.map((v, idx) => <div key={idx} className="marker-text">{v}</div>)}
+                {props.markers.map((v, idx) => <div
+                    key={idx}
+                    className="marker-text"
+                    onClick={() => {
+                        props.onChange(idx);
+                    }}
+                >{v}</div>)}
             </MarkerWrapper>
 
         </>
     }, [props.markers]);
 
     return (<>
-        <input value={props.value} style={style} autoFocus={props.autoFocus} onChange={props.onChange}
+        <input value={props.value} style={style} autoFocus={props.autoFocus} onChange={e => props.onChange(e.target.valueAsNumber)}
             className={RangeInputStyle} min={props.min ?? 0} max={props.max} type="range" list={markers ? "markers" : undefined} />
         {markers}
     </>);
@@ -95,17 +104,19 @@ const RangeInputStyle = injectStyle("range-input-style", cl => `
         background: var(--trackBackground);
         height: 8px;
         border-radius: 12px;
+        border: 1px solid var(--borderColor);
     }
     
     ${cl}::-moz-range-track {
         background: var(--trackBackground);
         height: 8px;
         border-radius: 12px;
+        border: 1px solid var(--borderColor);
     }
 
     ${cl}::-moz-range-thumb {
         cursor: ew-resize;
-        border: 1px solid var(--primaryLight);
+        border: none;
         height: 18px;
         width: 18px;
         border-radius: 12px;
@@ -115,7 +126,7 @@ const RangeInputStyle = injectStyle("range-input-style", cl => `
     
     ${cl}::-webkit-slider-thumb {
         cursor: ew-resize;
-        border: 1px solid var(--primaryLight);
+        border: none;
         height: 18px;
         width: 18px;
         border-radius: 12px;


### PR DESCRIPTION
Description should textSecondary
Product name margin shouldn't be there
Clicking the table wrongly opens the machine type selector
Clicking the numbers below the input range should jump to that option
Track color should be gray-ish (also divider)

<img width="1238" height="221" alt="Screenshot 2026-07-06 at 14 12 51" src="https://github.com/user-attachments/assets/132359d4-07df-4ef4-8558-376a97847852" />
<img width="1244" height="221" alt="Screenshot 2026-07-06 at 14 12 43" src="https://github.com/user-attachments/assets/3cdf7fac-3e0e-419a-92b3-17bb3882d3bd" />

Not sure about the gray color choice.