### PR TITLE
Fixes #5744. Also updates node and postgres in launcher

### DIFF
--- a/core2/pkg/migrations/00_module.go
+++ b/core2/pkg/migrations/00_module.go
@@ -38,4 +38,5 @@ func Init() {
 	db.AddMigration(grantV3())
 	db.AddMigration(grantV4())
 	db.AddMigration(projectsV5())
+	db.AddMigration(sshV1())
 }

--- a/core2/pkg/migrations/ssh.go
+++ b/core2/pkg/migrations/ssh.go
@@ -1,0 +1,46 @@
+package migrations
+
+import db "ucloud.dk/shared/pkg/database"
+
+func sshV1() db.MigrationScript {
+	return db.MigrationScript{
+		Id: "sshV1",
+		Execute: func(tx *db.Transaction) {
+			statements := []string{
+				// Rename all duplicates.
+				// Given the titles currently in prod it seems efficient enough just to add _x
+				`
+					WITH duplicates AS (
+						SELECT
+							id,
+							title,
+							row_number() OVER (
+								PARTITION BY owner, lower(title)
+								ORDER BY id
+							) AS rn
+						FROM app_orchestrator.ssh_keys
+					),
+					renamed AS (
+						SELECT
+							id,
+							title || '_' || rn AS new_title
+						FROM duplicates
+						WHERE rn > 1
+					)
+					UPDATE app_orchestrator.ssh_keys AS sk
+					SET title = r.new_title
+					FROM renamed AS r
+					WHERE sk.id = r.id;			    
+				`,
+				// Create uniqueness index
+				`
+					CREATE UNIQUE INDEX ssh_keys_owner_lower_title_idx
+					ON app_orchestrator.ssh_keys (owner, lower(title));
+				`,
+			}
+			for _, statement := range statements {
+				db.Exec(tx, statement, db.Params{})
+			}
+		},
+	}
+}

--- a/core2/pkg/orchestrator/ssh.go
+++ b/core2/pkg/orchestrator/ssh.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"ucloud.dk/core/pkg/coreutil"
 	accapi "ucloud.dk/shared/pkg/accounting"
 	db "ucloud.dk/shared/pkg/database"
@@ -54,6 +56,8 @@ func initSsh() {
 }
 
 func SshKeyCreate(actor rpc.Actor, keys []orcapi.SshKeySpecification) ([]fndapi.FindByStringId, *util.HttpError) {
+	seen := map[string]util.Empty{}
+
 	for _, key := range keys {
 		key.Key = strings.TrimSpace(key.Key)
 
@@ -83,37 +87,22 @@ func SshKeyCreate(actor rpc.Actor, keys []orcapi.SshKeySpecification) ([]fndapi.
 			)
 		}
 
-		// Checking if title already exists
-		exists := db.NewTx(func(tx *db.Transaction) bool {
-			row, _ := db.Get[struct {
-				Exists bool
-			}](
-				tx,
-				`
-				select exists (
-					select 1 
-					from app_orchestrator.ssh_keys 
-					where owner = :owner 
-					  and title = :title
-				) as exists
-				`,
-				db.Params{
-					"owner": actor.Username,
-					"title": key.Title,
-				},
-			)
-			return row.Exists
-		})
-		if exists {
+		//Checking if the request contains same title keys
+		normalized := strings.ToLower(key.Title)
+
+		if _, ok := seen[normalized]; ok {
 			return nil, util.HttpErr(
 				http.StatusBadRequest,
-				fmt.Sprintf("You already have a SSH key with the title: %v", key.Title),
+				fmt.Sprintf("Duplicate SSH key title: %v", key.Title),
 			)
 		}
+
+		seen[normalized] = util.Empty{}
+
 	}
 
 	now := time.Now()
-	result := db.NewTx(func(tx *db.Transaction) []fndapi.FindByStringId {
+	result, httpErr := db.NewTx2(func(tx *db.Transaction) ([]fndapi.FindByStringId, *util.HttpError) {
 		b := db.BatchNew(tx)
 
 		var ids []*util.Option[struct{ Id int }]
@@ -124,10 +113,12 @@ func SshKeyCreate(actor rpc.Actor, keys []orcapi.SshKeySpecification) ([]fndapi.
 			row := db.BatchGet[struct{ Id int }](
 				b,
 				`
-					insert into app_orchestrator.ssh_keys(owner, created_at, title, key)
-					values (:owner, :created_at, :title, :key)
-					returning id
-				`,
+                insert into app_orchestrator.ssh_keys(
+                    owner, created_at, title, key
+                )
+                values (:owner, :created_at, :title, :key)
+                returning id
+            `,
 				db.Params{
 					"owner":      actor.Username,
 					"created_at": now,
@@ -137,15 +128,44 @@ func SshKeyCreate(actor rpc.Actor, keys []orcapi.SshKeySpecification) ([]fndapi.
 			)
 			ids = append(ids, row)
 		}
+
 		db.BatchSend(b)
+
+		if err := tx.PeekError(); err != nil {
+			var pgErr *pgconn.PgError
+
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				tx.ConsumeError()
+
+				return nil, util.HttpErr(
+					http.StatusBadRequest,
+					"You already have a SSH key with this title",
+				)
+			}
+
+			tx.ConsumeError()
+			return nil, util.HttpErr(
+				http.StatusInternalServerError,
+				"Failed to create SSH key",
+			)
+		}
+
 		var results []fndapi.FindByStringId
 		for _, id := range ids {
 			if id.Present {
-				results = append(results, fndapi.FindByStringId{Id: strconv.Itoa(id.Value.Id)})
+				results = append(results, fndapi.FindByStringId{
+					Id: strconv.Itoa(id.Value.Id),
+				})
 			}
 		}
-		return results
+
+		return results, nil
 	})
+
+	if httpErr != nil {
+		return nil, httpErr
+	}
+
 	sshKeyNotifyProviders(actor)
 
 	return result, nil

--- a/core2/pkg/orchestrator/ssh.go
+++ b/core2/pkg/orchestrator/ssh.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -55,16 +56,59 @@ func initSsh() {
 func SshKeyCreate(actor rpc.Actor, keys []orcapi.SshKeySpecification) ([]fndapi.FindByStringId, *util.HttpError) {
 	for _, key := range keys {
 		key.Key = strings.TrimSpace(key.Key)
-		anyOk := false
-		for _, validPrefix := range validPrefixes {
-			if strings.HasPrefix(key.Key, validPrefix) {
-				anyOk = true
-				break
-			}
+
+		// Not empty key
+		if key.Key == "" {
+			return nil, util.HttpErr(
+				http.StatusBadRequest,
+				"Key cannot be blank",
+			)
 		}
 
-		if !anyOk {
-			return nil, util.HttpErr(http.StatusBadRequest, "Not a valid ssh key")
+		// Checking that key contains more than just the prefix
+		sshParts := strings.Fields(key.Key)
+
+		if len(sshParts) < 2 {
+			return nil, util.HttpErr(
+				http.StatusBadRequest,
+				"Not a valid SSH key (Missing key)",
+			)
+		}
+
+		// Checking prefix of ssh key is a valid prefix
+		if !slices.Contains(validPrefixes, sshParts[0]) {
+			return nil, util.HttpErr(
+				http.StatusBadRequest,
+				"Not a supported SSH key",
+			)
+		}
+
+		// Checking if title already exists
+		exists := db.NewTx(func(tx *db.Transaction) bool {
+			row, _ := db.Get[struct {
+				Exists bool
+			}](
+				tx,
+				`
+				select exists (
+					select 1 
+					from app_orchestrator.ssh_keys 
+					where owner = :owner 
+					  and title = :title
+				) as exists
+				`,
+				db.Params{
+					"owner": actor.Username,
+					"title": key.Title,
+				},
+			)
+			return row.Exists
+		})
+		if exists {
+			return nil, util.HttpErr(
+				http.StatusBadRequest,
+				fmt.Sprintf("You already have a SSH key with the title: %v", key.Title),
+			)
 		}
 	}
 

--- a/launcher-tool-go/pkg/launcher/svc_core.go
+++ b/launcher-tool-go/pkg/launcher/svc_core.go
@@ -154,7 +154,7 @@ func ServiceCore() {
 		data := AddVolume(postgres, "data")
 
 		AddService(postgres, DockerComposeService{
-			Image:       "postgres:15.0",
+			Image:       "postgres:17.0",
 			Hostname:    "postgres",
 			Restart:     "always",
 			Environment: []string{"POSTGRES_PASSWORD=postgrespassword"},

--- a/launcher-tool-go/pkg/launcher/svc_frontend.go
+++ b/launcher-tool-go/pkg/launcher/svc_frontend.go
@@ -11,7 +11,7 @@ func ServiceFrontend() {
 	}
 
 	AddService(service, DockerComposeService{
-		Image:      "node:22.21.0",
+		Image:      "node:24.19.0",
 		Hostname:   "frontend",
 		Restart:    "always",
 		WorkingDir: "/opt/ucloud",

--- a/launcher-tool-go/pkg/launcher/svc_provider_k8s.go
+++ b/launcher-tool-go/pkg/launcher/svc_provider_k8s.go
@@ -282,7 +282,7 @@ func ProviderK8s() {
 		data := AddVolume(postgres, "data")
 
 		AddService(postgres, DockerComposeService{
-			Image:       "postgres:15.0",
+			Image:       "postgres:17.0",
 			Hostname:    "k8s-postgres",
 			Restart:     "always",
 			Environment: []string{"POSTGRES_PASSWORD=postgrespassword"},

--- a/launcher-tool-go/pkg/launcher/svc_provider_slurm.go
+++ b/launcher-tool-go/pkg/launcher/svc_provider_slurm.go
@@ -218,7 +218,7 @@ func ProviderSlurm() {
 		data := AddVolume(postgres, "data")
 
 		AddService(postgres, DockerComposeService{
-			Image:       "postgres:15.0",
+			Image:       "postgres:17.0",
 			Hostname:    "slurm-postgres",
 			Restart:     "always",
 			Environment: []string{"POSTGRES_PASSWORD=postgrespassword"},

--- a/provider-integration/shared/pkg/database/database.go
+++ b/provider-integration/shared/pkg/database/database.go
@@ -537,7 +537,7 @@ func BatchGet[T any](batch *Batch, query string, args Params) *util.Option[T] {
 
 		if err := scanner.Scan(&scanned); err != nil && batch.Tx.Ok {
 			batch.Tx.Ok = false
-			batch.Tx.error = fmt.Errorf("Database select failed: %v. Query: %v", err, query)
+			batch.Tx.error = fmt.Errorf("Database select failed: %w. Query: %v", err, query)
 			return nil
 		}
 


### PR DESCRIPTION
Changed the prefix check to verify that it is actually a valid key type.

The previous code only checked the prefix, which meant something like `ssh-rsakdfskldfjasldkfjskle` was accepted as a valid key type because it started with `ssh-rsa`.

I also added a check to ensure that a key is present after the prefix, so empty keys are rejected.

One question: should we also check whether the key has already been uploaded and inform the user that it already exists? Or is there a good reason to allow multiple SSH keys with the same key?
